### PR TITLE
Configure semantic-release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,8 @@ name: release
 on:
   push:
     # TODO: This `branches` array is for testing purposes; replace branch with "main" before merging this PR.
-    branches: [configure-semantic-release]
+    # branches: [configure-semantic-release]
+    branches: [main]
   # Specify that this workflow depends on the workflow(s) below completing successfully.
   workflow_run:
     workflows: [build-check-test]
@@ -70,4 +71,4 @@ jobs:
           # GITHUB_TOKEN: ${{ steps.op-secrets.outputs.TEMP_WEB_DEV_DEPS_GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ steps.op-secrets.outputs.WEB_DEV_DEPS_NPM_TOKEN }}
-        run: npx semantic-release --dry-run --extends ./lib/semantic-release.config.cjs
+        run: npx semantic-release --extends ./lib/semantic-release.config.cjs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,64 @@
+# Adapted from "GitHub Actions - `.github/workflows/release.yml` configuration for Node projects" CI configuration recipe:
+# https://semantic-release.gitbook.io/semantic-release/recipes/ci-configurations/github-actions#github-workflows-release.yml-configuration-for-node-projects
+
+# To test this `release` GitHub Action workflow locally:
+# 1. Prerequisite 1: Have `act` installed.
+# 2. Prerequisite 2: Generate a temporary GitHub Personal Access Token (PAT).
+#    - Navigate to the https://github.com/settings/tokens page.
+#    - Name the PAT `TEMP_DR_DEVDEPS_GITHUB_TOKEN`.
+#    - Configure the token to have the `repo` and `write:packages` scopes.
+#    - Copy the resulting `ghp_...` token value and store it in 1Password as an item in the "SA - Repos_GitHub" vault.
+#    - Temporarily change `${{ secrets.GITHUB_TOKEN }}` to `${{ steps.op-credentials.outputs.TEMP_DR_DEVDEPS_GITHUB_TOKEN }}`.
+# 3. Prerequisite 3: Temporarily pass the `--dry-run` flag following the `npx semantic-release` command.
+# 4. Use the `npm run gha:release` command (passing the `OP_SERVICE_ACCOUNT_TOKEN` secret when prompted) to perform a dry-run of the release.
+# 5. Delete the `TEMP_DR_DEVDEPS_GITHUB_TOKEN` PAT and revert the temporary changes to this file after local testing is completed.
+
+name: release
+on:
+  push:
+    # TODO: This `branches` array is for testing purposes; replace branch with "main" before merging this PR.
+    branches: [configure-semantic-release]
+  # Specify that this workflow depends on the workflow(s) below completing successfully.
+  workflow_run:
+    workflows: [build-check-test]
+    types: [completed]
+permissions:
+  contents: read # To be able to Git checkout the repository.
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # To be able to publish a GitHub release.
+      issues: write # To be able to comment on released issues.
+      pull-requests: write # To be able to comment on released pull requests.
+      id-token: write # To enable use of OIDC for NPM provenance.
+    steps:
+      - name: Load secrets from 1Password
+        id: op-credentials
+        uses: 1password/load-secrets-action@v2
+        with:
+          export-env: false
+          unset-previous: true
+        env:
+          # https://github.com/dustin-ruetz/dr-devdeps/settings/secrets/actions
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          # Human-readable 1Password CLI secret reference - 'op://SA - Repos_GitHub/dr-devdeps/$FIELD_LABEL'
+          TEMP_DR_DEVDEPS_GITHUB_TOKEN: "op://yhyrnlsxmxerazmg3j2rvjxzpq/bws336u3hgbaf4y6zszsiw4xw4/TEMP_DR_DEVDEPS_GITHUB_TOKEN"
+          DR_DEVDEPS_NPM_TOKEN: "op://yhyrnlsxmxerazmg3j2rvjxzpq/bws336u3hgbaf4y6zszsiw4xw4/DR_DEVDEPS_NPM_TOKEN"
+      - name: Git checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          # Specify the Node.js version by referencing the .node-version file that's located in the root of the repo.
+          node-version-file: .node-version
+      - name: Release package
+        # semantic-release requires specific key names for environment variables.
+        # https://semantic-release.gitbook.io/semantic-release/usage/ci-configuration#authentication
+        env:
+          GITHUB_TOKEN: ${{ steps.op-credentials.outputs.TEMP_DR_DEVDEPS_GITHUB_TOKEN }}
+          # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ steps.op-credentials.outputs.DR_DEVDEPS_NPM_TOKEN }}
+        run: npx semantic-release@23 --dry-run

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,4 +61,4 @@ jobs:
           GITHUB_TOKEN: ${{ steps.op-credentials.outputs.TEMP_DR_DEVDEPS_GITHUB_TOKEN }}
           # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ steps.op-credentials.outputs.DR_DEVDEPS_NPM_TOKEN }}
-        run: npx semantic-release@23 --dry-run
+        run: npx semantic-release@23 --dry-run --extends ./lib/semantic-release.config.cjs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
           # https://github.com/dustin-ruetz/web-dev-deps/settings/secrets/actions
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           # Human-readable 1Password CLI secret reference - 'op://SA - Repos_GitHub/web-dev-deps/$FIELD_LABEL'
-          TEMP_WEB_DEV_DEPS_GITHUB_TOKEN: "op://yhyrnlsxmxerazmg3j2rvjxzpq/bws336u3hgbaf4y6zszsiw4xw4/TEMP_WEB_DEV_DEPS_GITHUB_TOKEN"
+          # TEMP_WEB_DEV_DEPS_GITHUB_TOKEN: "op://yhyrnlsxmxerazmg3j2rvjxzpq/bws336u3hgbaf4y6zszsiw4xw4/TEMP_WEB_DEV_DEPS_GITHUB_TOKEN"
           WEB_DEV_DEPS_NPM_TOKEN: "op://yhyrnlsxmxerazmg3j2rvjxzpq/bws336u3hgbaf4y6zszsiw4xw4/WEB_DEV_DEPS_NPM_TOKEN"
       - name: Git checkout repository
         uses: actions/checkout@v4
@@ -67,7 +67,7 @@ jobs:
         # semantic-release requires specific key names for environment variables.
         # https://semantic-release.gitbook.io/semantic-release/usage/ci-configuration#authentication
         env:
-          GITHUB_TOKEN: ${{ steps.op-secrets.outputs.TEMP_WEB_DEV_DEPS_GITHUB_TOKEN }}
-          # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN: ${{ steps.op-secrets.outputs.TEMP_WEB_DEV_DEPS_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ steps.op-secrets.outputs.WEB_DEV_DEPS_NPM_TOKEN }}
         run: npx semantic-release --dry-run --extends ./lib/semantic-release.config.cjs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,6 +49,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Excerpt from https://semantic-release.gitbook.io/semantic-release/recipes/ci-configurations/github-actions#pushing-package.json-changes-to-your-repository:
+          # > The actions/checkout `persist-credentials` option needs to be `false`, otherwise the generated `GITHUB_TOKEN` will interfere with the custom one.
+          persist-credentials: false
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,6 +54,11 @@ jobs:
         with:
           # Specify the Node.js version by referencing the .node-version file that's located in the root of the repo.
           node-version-file: .node-version
+      - name: Install dependencies and build library
+        run: npm clean-install
+      # Verify the integrity of provenance attestations and registry signatures for installed dependencies.
+      - name: Audit dependency signatures
+        run: npm audit signatures
       - name: Release package
         # semantic-release requires specific key names for environment variables.
         # https://semantic-release.gitbook.io/semantic-release/usage/ci-configuration#authentication
@@ -61,4 +66,4 @@ jobs:
           GITHUB_TOKEN: ${{ steps.op-credentials.outputs.TEMP_DR_DEVDEPS_GITHUB_TOKEN }}
           # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ steps.op-credentials.outputs.DR_DEVDEPS_NPM_TOKEN }}
-        run: npx semantic-release@23 --dry-run --extends ./lib/semantic-release.config.cjs
+        run: npx semantic-release --dry-run --extends ./lib/semantic-release.config.cjs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,8 +8,8 @@
 #    - Name the PAT `TEMP_WEB_DEV_DEPS_GITHUB_TOKEN`.
 #    - Configure the token to have the `repo` and `write:packages` scopes.
 #    - Copy the resulting `ghp_...` token value and store it in 1Password as an item in the "SA - Repos_GitHub" vault.
-#    - Temporarily set the `TEMP_WEB_DEV_DEPS_GITHUB_TOKEN` as an environment variable in the `op-credentials` step.
-#    - Temporarily change `${{ secrets.GITHUB_TOKEN }}` to `${{ steps.op-credentials.outputs.TEMP_WEB_DEV_DEPS_GITHUB_TOKEN }}`.
+#    - Temporarily set the `TEMP_WEB_DEV_DEPS_GITHUB_TOKEN` as an environment variable in the `op-secrets` step.
+#    - Temporarily change `${{ secrets.GITHUB_TOKEN }}` to `${{ steps.op-secrets.outputs.TEMP_WEB_DEV_DEPS_GITHUB_TOKEN }}`.
 # 3. Prerequisite 3: Temporarily pass the `--dry-run` flag following the `npx semantic-release` command.
 # 4. Use the `npm run gha:release` command (passing the `OP_SERVICE_ACCOUNT_TOKEN` secret when prompted) to perform a dry-run of the release.
 # 5. Delete the `TEMP_WEB_DEV_DEPS_GITHUB_TOKEN` PAT and revert the temporary changes listed above after local testing is completed.
@@ -35,7 +35,7 @@ jobs:
       id-token: write # To enable use of OIDC for NPM provenance.
     steps:
       - name: Load secrets from 1Password
-        id: op-credentials
+        id: op-secrets
         uses: 1password/load-secrets-action@v2
         with:
           export-env: false
@@ -67,7 +67,7 @@ jobs:
         # semantic-release requires specific key names for environment variables.
         # https://semantic-release.gitbook.io/semantic-release/usage/ci-configuration#authentication
         env:
-          GITHUB_TOKEN: ${{ steps.op-credentials.outputs.TEMP_WEB_DEV_DEPS_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.op-secrets.outputs.TEMP_WEB_DEV_DEPS_GITHUB_TOKEN }}
           # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ steps.op-credentials.outputs.WEB_DEV_DEPS_NPM_TOKEN }}
+          NPM_TOKEN: ${{ steps.op-secrets.outputs.WEB_DEV_DEPS_NPM_TOKEN }}
         run: npx semantic-release --dry-run --extends ./lib/semantic-release.config.cjs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,13 +5,13 @@
 # 1. Prerequisite 1: Have `act` installed.
 # 2. Prerequisite 2: Generate a temporary GitHub Personal Access Token (PAT).
 #    - Navigate to the https://github.com/settings/tokens page.
-#    - Name the PAT `TEMP_DR_DEVDEPS_GITHUB_TOKEN`.
+#    - Name the PAT `TEMP_WEB_DEV_DEPS_GITHUB_TOKEN`.
 #    - Configure the token to have the `repo` and `write:packages` scopes.
 #    - Copy the resulting `ghp_...` token value and store it in 1Password as an item in the "SA - Repos_GitHub" vault.
-#    - Temporarily change `${{ secrets.GITHUB_TOKEN }}` to `${{ steps.op-credentials.outputs.TEMP_DR_DEVDEPS_GITHUB_TOKEN }}`.
+#    - Temporarily change `${{ secrets.GITHUB_TOKEN }}` to `${{ steps.op-credentials.outputs.TEMP_WEB_DEV_DEPS_GITHUB_TOKEN }}`.
 # 3. Prerequisite 3: Temporarily pass the `--dry-run` flag following the `npx semantic-release` command.
 # 4. Use the `npm run gha:release` command (passing the `OP_SERVICE_ACCOUNT_TOKEN` secret when prompted) to perform a dry-run of the release.
-# 5. Delete the `TEMP_DR_DEVDEPS_GITHUB_TOKEN` PAT and revert the temporary changes to this file after local testing is completed.
+# 5. Delete the `TEMP_WEB_DEV_DEPS_GITHUB_TOKEN` PAT and revert the temporary changes to this file after local testing is completed.
 
 name: release
 on:
@@ -40,11 +40,11 @@ jobs:
           export-env: false
           unset-previous: true
         env:
-          # https://github.com/dustin-ruetz/dr-devdeps/settings/secrets/actions
+          # https://github.com/dustin-ruetz/web-dev-deps/settings/secrets/actions
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          # Human-readable 1Password CLI secret reference - 'op://SA - Repos_GitHub/dr-devdeps/$FIELD_LABEL'
-          TEMP_DR_DEVDEPS_GITHUB_TOKEN: "op://yhyrnlsxmxerazmg3j2rvjxzpq/bws336u3hgbaf4y6zszsiw4xw4/TEMP_DR_DEVDEPS_GITHUB_TOKEN"
-          DR_DEVDEPS_NPM_TOKEN: "op://yhyrnlsxmxerazmg3j2rvjxzpq/bws336u3hgbaf4y6zszsiw4xw4/DR_DEVDEPS_NPM_TOKEN"
+          # Human-readable 1Password CLI secret reference - 'op://SA - Repos_GitHub/web-dev-deps/$FIELD_LABEL'
+          TEMP_WEB_DEV_DEPS_GITHUB_TOKEN: "op://yhyrnlsxmxerazmg3j2rvjxzpq/bws336u3hgbaf4y6zszsiw4xw4/TEMP_WEB_DEV_DEPS_GITHUB_TOKEN"
+          WEB_DEV_DEPS_NPM_TOKEN: "op://yhyrnlsxmxerazmg3j2rvjxzpq/bws336u3hgbaf4y6zszsiw4xw4/WEB_DEV_DEPS_NPM_TOKEN"
       - name: Git checkout repository
         uses: actions/checkout@v4
         with:
@@ -66,7 +66,7 @@ jobs:
         # semantic-release requires specific key names for environment variables.
         # https://semantic-release.gitbook.io/semantic-release/usage/ci-configuration#authentication
         env:
-          GITHUB_TOKEN: ${{ steps.op-credentials.outputs.TEMP_DR_DEVDEPS_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.op-credentials.outputs.TEMP_WEB_DEV_DEPS_GITHUB_TOKEN }}
           # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ steps.op-credentials.outputs.DR_DEVDEPS_NPM_TOKEN }}
+          NPM_TOKEN: ${{ steps.op-credentials.outputs.WEB_DEV_DEPS_NPM_TOKEN }}
         run: npx semantic-release --dry-run --extends ./lib/semantic-release.config.cjs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,10 +8,11 @@
 #    - Name the PAT `TEMP_WEB_DEV_DEPS_GITHUB_TOKEN`.
 #    - Configure the token to have the `repo` and `write:packages` scopes.
 #    - Copy the resulting `ghp_...` token value and store it in 1Password as an item in the "SA - Repos_GitHub" vault.
+#    - Temporarily set the `TEMP_WEB_DEV_DEPS_GITHUB_TOKEN` as an environment variable in the `op-credentials` step.
 #    - Temporarily change `${{ secrets.GITHUB_TOKEN }}` to `${{ steps.op-credentials.outputs.TEMP_WEB_DEV_DEPS_GITHUB_TOKEN }}`.
 # 3. Prerequisite 3: Temporarily pass the `--dry-run` flag following the `npx semantic-release` command.
 # 4. Use the `npm run gha:release` command (passing the `OP_SERVICE_ACCOUNT_TOKEN` secret when prompted) to perform a dry-run of the release.
-# 5. Delete the `TEMP_WEB_DEV_DEPS_GITHUB_TOKEN` PAT and revert the temporary changes to this file after local testing is completed.
+# 5. Delete the `TEMP_WEB_DEV_DEPS_GITHUB_TOKEN` PAT and revert the temporary changes listed above after local testing is completed.
 
 name: release
 on:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dr-devdeps
+# web-dev-deps
 
 This repository is an installable package that provides standardized dependencies and configurations for other JavaScript/TypeScript projects to consume.
 
@@ -9,7 +9,7 @@ This repository is an installable package that provides standardized dependencie
 // Created using the `Shinotatwu-DS.file-tree-generator` extension for Visual Studio Code.
 📂 consuming-repo
 ┣ 📂 node_modules
-┃ ┗ 📂 dr-devdeps
+┃ ┗ 📂 @dustin-ruetz/web-dev-deps
 ┃ ┃ ┗ 📂 lib
 ┃ ┃ ┃ ┗ 📄 *.config.js
 ┃ ┃ ┗ 📄 tsconfig.json

--- a/__tests__/packageJSON.test.ts
+++ b/__tests__/packageJSON.test.ts
@@ -1,8 +1,8 @@
 import packageJSON from "../package.json";
 
 test("the most important configuration options are correct", () => {
+	expect(packageJSON.name).toEqual("@dustin-ruetz/web-dev-deps");
 	expect(packageJSON.author).toEqual("Dustin Ruetz");
-	expect(packageJSON.name).toEqual("dr-devdeps");
 	expect(packageJSON.type).toEqual("module");
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
 				"@commitlint/config-conventional": "19.2.2",
 				"@prettier/plugin-pug": "3.0.0",
 				"@prettier/plugin-xml": "3.4.1",
+				"@semantic-release/changelog": "6.0.3",
+				"@semantic-release/git": "10.0.1",
 				"@swc/core": "1.5.7",
 				"@swc/jest": "0.2.36",
 				"@tsconfig/strictest": "2.0.5",
@@ -2158,6 +2160,59 @@
 			"resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
 			"integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="
 		},
+		"node_modules/@semantic-release/changelog": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.3.tgz",
+			"integrity": "sha512-dZuR5qByyfe3Y03TpmCvAxCyTnp7r5XwtHRf/8vD9EAn4ZWbavUX8adMtXYzE86EVh0gyLA7lm5yW4IV30XUag==",
+			"dependencies": {
+				"@semantic-release/error": "^3.0.0",
+				"aggregate-error": "^3.0.0",
+				"fs-extra": "^11.0.0",
+				"lodash": "^4.17.4"
+			},
+			"engines": {
+				"node": ">=14.17"
+			},
+			"peerDependencies": {
+				"semantic-release": ">=18.0.0"
+			}
+		},
+		"node_modules/@semantic-release/changelog/node_modules/@semantic-release/error": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+			"integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/@semantic-release/changelog/node_modules/aggregate-error": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"dependencies": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@semantic-release/changelog/node_modules/clean-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@semantic-release/changelog/node_modules/indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/@semantic-release/commit-analyzer": {
 			"version": "12.0.0",
 			"resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-12.0.0.tgz",
@@ -2184,6 +2239,71 @@
 			"integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@semantic-release/git": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-10.0.1.tgz",
+			"integrity": "sha512-eWrx5KguUcU2wUPaO6sfvZI0wPafUKAMNC18aXY4EnNcrZL86dEmpNVnC9uMpGZkmZJ9EfCVJBQx4pV4EMGT1w==",
+			"dependencies": {
+				"@semantic-release/error": "^3.0.0",
+				"aggregate-error": "^3.0.0",
+				"debug": "^4.0.0",
+				"dir-glob": "^3.0.0",
+				"execa": "^5.0.0",
+				"lodash": "^4.17.4",
+				"micromatch": "^4.0.0",
+				"p-reduce": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.17"
+			},
+			"peerDependencies": {
+				"semantic-release": ">=18.0.0"
+			}
+		},
+		"node_modules/@semantic-release/git/node_modules/@semantic-release/error": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+			"integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/@semantic-release/git/node_modules/aggregate-error": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"dependencies": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@semantic-release/git/node_modules/clean-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@semantic-release/git/node_modules/indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@semantic-release/git/node_modules/p-reduce": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
+			"integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/@semantic-release/github": {
@@ -7366,6 +7486,11 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"node_modules/lodash-es": {
 			"version": "4.17.21",
@@ -14265,6 +14390,43 @@
 			"resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
 			"integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="
 		},
+		"@semantic-release/changelog": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.3.tgz",
+			"integrity": "sha512-dZuR5qByyfe3Y03TpmCvAxCyTnp7r5XwtHRf/8vD9EAn4ZWbavUX8adMtXYzE86EVh0gyLA7lm5yW4IV30XUag==",
+			"requires": {
+				"@semantic-release/error": "^3.0.0",
+				"aggregate-error": "^3.0.0",
+				"fs-extra": "^11.0.0",
+				"lodash": "^4.17.4"
+			},
+			"dependencies": {
+				"@semantic-release/error": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+					"integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw=="
+				},
+				"aggregate-error": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+					"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+					"requires": {
+						"clean-stack": "^2.0.0",
+						"indent-string": "^4.0.0"
+					}
+				},
+				"clean-stack": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+					"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
+				},
+				"indent-string": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+					"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+				}
+			}
+		},
 		"@semantic-release/commit-analyzer": {
 			"version": "12.0.0",
 			"resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-12.0.0.tgz",
@@ -14283,6 +14445,52 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
 			"integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ=="
+		},
+		"@semantic-release/git": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-10.0.1.tgz",
+			"integrity": "sha512-eWrx5KguUcU2wUPaO6sfvZI0wPafUKAMNC18aXY4EnNcrZL86dEmpNVnC9uMpGZkmZJ9EfCVJBQx4pV4EMGT1w==",
+			"requires": {
+				"@semantic-release/error": "^3.0.0",
+				"aggregate-error": "^3.0.0",
+				"debug": "^4.0.0",
+				"dir-glob": "^3.0.0",
+				"execa": "^5.0.0",
+				"lodash": "^4.17.4",
+				"micromatch": "^4.0.0",
+				"p-reduce": "^2.0.0"
+			},
+			"dependencies": {
+				"@semantic-release/error": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+					"integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw=="
+				},
+				"aggregate-error": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+					"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+					"requires": {
+						"clean-stack": "^2.0.0",
+						"indent-string": "^4.0.0"
+					}
+				},
+				"clean-stack": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+					"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
+				},
+				"indent-string": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+					"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+				},
+				"p-reduce": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
+					"integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw=="
+				}
+			}
 		},
 		"@semantic-release/github": {
 			"version": "10.0.4",
@@ -17825,6 +18033,11 @@
 			"requires": {
 				"p-locate": "^4.1.0"
 			}
+		},
+		"lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"lodash-es": {
 			"version": "4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "dr-devdeps",
+	"name": "@dustin-ruetz/web-dev-deps",
 	"version": "0.18.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "dr-devdeps",
+			"name": "@dustin-ruetz/web-dev-deps",
 			"version": "0.18.0",
 			"hasInstallScript": true,
 			"license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
 				"lint-staged": "15.2.2",
 				"npm-run-all2": "6.1.2",
 				"prettier": "3.2.5",
+				"semantic-release": "23.1.1",
 				"typescript": "5.4.5"
 			},
 			"devDependencies": {
@@ -634,6 +635,15 @@
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
+		},
+		"node_modules/@colors/colors": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+			"optional": true,
+			"engines": {
+				"node": ">=0.1.90"
+			}
 		},
 		"node_modules/@commitlint/cli": {
 			"version": "19.3.0",
@@ -1937,6 +1947,176 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/@octokit/auth-token": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.1.tgz",
+			"integrity": "sha512-rh3G3wDO8J9wSjfI436JUKzHIxq8NaiL0tVeB2aXmG6p/9859aUOAjA9pmSPNGGZxfwmaJ9ozOJImuNVJdpvbA==",
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/core": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.2.tgz",
+			"integrity": "sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==",
+			"dependencies": {
+				"@octokit/auth-token": "^5.0.0",
+				"@octokit/graphql": "^8.0.0",
+				"@octokit/request": "^9.0.0",
+				"@octokit/request-error": "^6.0.1",
+				"@octokit/types": "^13.0.0",
+				"before-after-hook": "^3.0.2",
+				"universal-user-agent": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/endpoint": {
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.1.tgz",
+			"integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
+			"dependencies": {
+				"@octokit/types": "^13.0.0",
+				"universal-user-agent": "^7.0.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/graphql": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.1.1.tgz",
+			"integrity": "sha512-ukiRmuHTi6ebQx/HFRCXKbDlOh/7xEV6QUXaE7MJEKGNAncGI/STSbOkl12qVXZrfZdpXctx5O9X1AIaebiDBg==",
+			"dependencies": {
+				"@octokit/request": "^9.0.0",
+				"@octokit/types": "^13.0.0",
+				"universal-user-agent": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/openapi-types": {
+			"version": "22.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
+			"integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg=="
+		},
+		"node_modules/@octokit/plugin-paginate-rest": {
+			"version": "11.3.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.0.tgz",
+			"integrity": "sha512-n4znWfRinnUQF6TPyxs7EctSAA3yVSP4qlJP2YgI3g9d4Ae2n5F3XDOjbUluKRxPU3rfsgpOboI4O4VtPc6Ilg==",
+			"dependencies": {
+				"@octokit/types": "^13.5.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=6"
+			}
+		},
+		"node_modules/@octokit/plugin-retry": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-7.1.1.tgz",
+			"integrity": "sha512-G9Ue+x2odcb8E1XIPhaFBnTTIrrUDfXN05iFXiqhR+SeeeDMMILcAnysOsxUpEWcQp2e5Ft397FCXTcPkiPkLw==",
+			"dependencies": {
+				"@octokit/request-error": "^6.0.0",
+				"@octokit/types": "^13.0.0",
+				"bottleneck": "^2.15.3"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=6"
+			}
+		},
+		"node_modules/@octokit/plugin-throttling": {
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-9.3.0.tgz",
+			"integrity": "sha512-B5YTToSRTzNSeEyssnrT7WwGhpIdbpV9NKIs3KyTWHX6PhpYn7gqF/+lL3BvsASBM3Sg5BAUYk7KZx5p/Ec77w==",
+			"dependencies": {
+				"@octokit/types": "^13.0.0",
+				"bottleneck": "^2.15.3"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "^6.0.0"
+			}
+		},
+		"node_modules/@octokit/request": {
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.1.tgz",
+			"integrity": "sha512-pyAguc0p+f+GbQho0uNetNQMmLG1e80WjkIaqqgUkihqUp0boRU6nKItXO4VWnr+nbZiLGEyy4TeKRwqaLvYgw==",
+			"dependencies": {
+				"@octokit/endpoint": "^10.0.0",
+				"@octokit/request-error": "^6.0.1",
+				"@octokit/types": "^13.1.0",
+				"universal-user-agent": "^7.0.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/request-error": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.1.tgz",
+			"integrity": "sha512-1mw1gqT3fR/WFvnoVpY/zUM2o/XkMs/2AszUUG9I69xn0JFLv6PGkPhNk5lbfvROs79wiS0bqiJNxfCZcRJJdg==",
+			"dependencies": {
+				"@octokit/types": "^13.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/types": {
+			"version": "13.5.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
+			"integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
+			"dependencies": {
+				"@octokit/openapi-types": "^22.2.0"
+			}
+		},
+		"node_modules/@pnpm/config.env-replace": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+			"integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+			"engines": {
+				"node": ">=12.22.0"
+			}
+		},
+		"node_modules/@pnpm/network.ca-file": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+			"integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+			"dependencies": {
+				"graceful-fs": "4.2.10"
+			},
+			"engines": {
+				"node": ">=12.22.0"
+			}
+		},
+		"node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+		},
+		"node_modules/@pnpm/npm-conf": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.2.2.tgz",
+			"integrity": "sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==",
+			"dependencies": {
+				"@pnpm/config.env-replace": "^1.1.0",
+				"@pnpm/network.ca-file": "^1.0.1",
+				"config-chain": "^1.1.11"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@prettier/plugin-pug": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@prettier/plugin-pug/-/plugin-pug-3.0.0.tgz",
@@ -1973,10 +2153,358 @@
 				"prettier": "^3.0.0"
 			}
 		},
+		"node_modules/@sec-ant/readable-stream": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+			"integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="
+		},
+		"node_modules/@semantic-release/commit-analyzer": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-12.0.0.tgz",
+			"integrity": "sha512-qG+md5gdes+xa8zP7lIo1fWE17zRdO8yMCaxh9lyL65TQleoSv8WHHOqRURfghTytUh+NpkSyBprQ5hrkxOKVQ==",
+			"dependencies": {
+				"conventional-changelog-angular": "^7.0.0",
+				"conventional-commits-filter": "^4.0.0",
+				"conventional-commits-parser": "^5.0.0",
+				"debug": "^4.0.0",
+				"import-from-esm": "^1.0.3",
+				"lodash-es": "^4.17.21",
+				"micromatch": "^4.0.2"
+			},
+			"engines": {
+				"node": ">=20.8.1"
+			},
+			"peerDependencies": {
+				"semantic-release": ">=20.1.0"
+			}
+		},
+		"node_modules/@semantic-release/error": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+			"integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@semantic-release/github": {
+			"version": "10.0.4",
+			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-10.0.4.tgz",
+			"integrity": "sha512-eHCfW3jlzax5OKd5nTovlvoCdg+b9YBa31M2JGT1KmzmJR3TIalu2ahVU+V/xATVeOx+S8fbCiPnBBgMlzH5Vw==",
+			"dependencies": {
+				"@octokit/core": "^6.0.0",
+				"@octokit/plugin-paginate-rest": "^11.0.0",
+				"@octokit/plugin-retry": "^7.0.0",
+				"@octokit/plugin-throttling": "^9.0.0",
+				"@semantic-release/error": "^4.0.0",
+				"aggregate-error": "^5.0.0",
+				"debug": "^4.3.4",
+				"dir-glob": "^3.0.1",
+				"globby": "^14.0.0",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.0",
+				"issue-parser": "^7.0.0",
+				"lodash-es": "^4.17.21",
+				"mime": "^4.0.0",
+				"p-filter": "^4.0.0",
+				"url-join": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=20.8.1"
+			},
+			"peerDependencies": {
+				"semantic-release": ">=20.1.0"
+			}
+		},
+		"node_modules/@semantic-release/github/node_modules/agent-base": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+			"integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+			"dependencies": {
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@semantic-release/github/node_modules/globby": {
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-14.0.1.tgz",
+			"integrity": "sha512-jOMLD2Z7MAhyG8aJpNOpmziMOP4rPLcc95oQPKXBazW82z+CEgPFBQvEpRUa1KeIMUJo4Wsm+q6uzO/Q/4BksQ==",
+			"dependencies": {
+				"@sindresorhus/merge-streams": "^2.1.0",
+				"fast-glob": "^3.3.2",
+				"ignore": "^5.2.4",
+				"path-type": "^5.0.0",
+				"slash": "^5.1.0",
+				"unicorn-magic": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/github/node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@semantic-release/github/node_modules/https-proxy-agent": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+			"integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+			"dependencies": {
+				"agent-base": "^7.0.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@semantic-release/github/node_modules/path-type": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+			"integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/github/node_modules/slash": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm": {
+			"version": "12.0.1",
+			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-12.0.1.tgz",
+			"integrity": "sha512-/6nntGSUGK2aTOI0rHPwY3ZjgY9FkXmEHbW9Kr+62NVOsyqpKKeP0lrCH+tphv+EsNdJNmqqwijTEnVWUMQ2Nw==",
+			"dependencies": {
+				"@semantic-release/error": "^4.0.0",
+				"aggregate-error": "^5.0.0",
+				"execa": "^9.0.0",
+				"fs-extra": "^11.0.0",
+				"lodash-es": "^4.17.21",
+				"nerf-dart": "^1.0.0",
+				"normalize-url": "^8.0.0",
+				"npm": "^10.5.0",
+				"rc": "^1.2.8",
+				"read-pkg": "^9.0.0",
+				"registry-auth-token": "^5.0.0",
+				"semver": "^7.1.2",
+				"tempy": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=20.8.1"
+			},
+			"peerDependencies": {
+				"semantic-release": ">=20.1.0"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/@sindresorhus/merge-streams": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+			"integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/execa": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-9.1.0.tgz",
+			"integrity": "sha512-lSgHc4Elo2m6bUDhc3Hl/VxvUDJdQWI40RZ4KMY9bKRc+hgMOT7II/JjbNDhI8VnMtrCb7U/fhpJIkLORZozWw==",
+			"dependencies": {
+				"@sindresorhus/merge-streams": "^4.0.0",
+				"cross-spawn": "^7.0.3",
+				"figures": "^6.1.0",
+				"get-stream": "^9.0.0",
+				"human-signals": "^7.0.0",
+				"is-plain-obj": "^4.1.0",
+				"is-stream": "^4.0.1",
+				"npm-run-path": "^5.2.0",
+				"pretty-ms": "^9.0.0",
+				"signal-exit": "^4.1.0",
+				"strip-final-newline": "^4.0.0",
+				"yoctocolors": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/get-stream": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+			"integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+			"dependencies": {
+				"@sec-ant/readable-stream": "^0.4.1",
+				"is-stream": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/human-signals": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-7.0.0.tgz",
+			"integrity": "sha512-74kytxOUSvNbjrT9KisAbaTZ/eJwD/LrbM/kh5j0IhPuJzwuA19dWvniFGwBzN9rVjg+O/e+F310PjObDXS+9Q==",
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/is-stream": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+			"integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/npm-run-path": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+			"integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+			"dependencies": {
+				"path-key": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/path-key": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/semver": {
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/strip-final-newline": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+			"integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/release-notes-generator": {
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-13.0.0.tgz",
+			"integrity": "sha512-LEeZWb340keMYuREMyxrODPXJJ0JOL8D/mCl74B4LdzbxhtXV2LrPN2QBEcGJrlQhoqLO0RhxQb6masHytKw+A==",
+			"dependencies": {
+				"conventional-changelog-angular": "^7.0.0",
+				"conventional-changelog-writer": "^7.0.0",
+				"conventional-commits-filter": "^4.0.0",
+				"conventional-commits-parser": "^5.0.0",
+				"debug": "^4.0.0",
+				"get-stream": "^7.0.0",
+				"import-from-esm": "^1.0.3",
+				"into-stream": "^7.0.0",
+				"lodash-es": "^4.17.21",
+				"read-pkg-up": "^11.0.0"
+			},
+			"engines": {
+				"node": ">=20.8.1"
+			},
+			"peerDependencies": {
+				"semantic-release": ">=20.1.0"
+			}
+		},
+		"node_modules/@semantic-release/release-notes-generator/node_modules/get-stream": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.1.tgz",
+			"integrity": "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ==",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@sinclair/typebox": {
 			"version": "0.27.8",
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
 			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
+		},
+		"node_modules/@sindresorhus/is": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/is?sponsor=1"
+			}
+		},
+		"node_modules/@sindresorhus/merge-streams": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+			"integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/@sinonjs/commons": {
 			"version": "3.0.0",
@@ -2348,6 +2876,11 @@
 				"undici-types": "~5.26.4"
 			}
 		},
+		"node_modules/@types/normalize-package-data": {
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="
+		},
 		"node_modules/@types/stack-utils": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
@@ -2647,6 +3180,21 @@
 				"node": ">= 6.0.0"
 			}
 		},
+		"node_modules/aggregate-error": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
+			"integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
+			"dependencies": {
+				"clean-stack": "^5.2.0",
+				"indent-string": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2698,6 +3246,11 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/any-promise": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
+		},
 		"node_modules/anymatch": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -2718,6 +3271,26 @@
 				"sprintf-js": "~1.0.2"
 			}
 		},
+		"node_modules/argv-formatter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
+			"integrity": "sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw=="
+		},
+		"node_modules/array-buffer-byte-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+			"integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+			"dependencies": {
+				"call-bind": "^1.0.5",
+				"is-array-buffer": "^3.0.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/array-ify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
@@ -2731,10 +3304,45 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/arraybuffer.prototype.slice": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
+			"integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+			"dependencies": {
+				"array-buffer-byte-length": "^1.0.1",
+				"call-bind": "^1.0.5",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.22.3",
+				"es-errors": "^1.2.1",
+				"get-intrinsic": "^1.2.3",
+				"is-array-buffer": "^3.0.4",
+				"is-shared-array-buffer": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+		},
+		"node_modules/available-typed-arrays": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+			"dependencies": {
+				"possible-typed-array-names": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/babel-jest": {
 			"version": "29.7.0",
@@ -2826,6 +3434,16 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+		},
+		"node_modules/before-after-hook": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+			"integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A=="
+		},
+		"node_modules/bottleneck": {
+			"version": "2.19.5",
+			"resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+			"integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
@@ -3002,6 +3620,31 @@
 			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
 			"integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
 		},
+		"node_modules/clean-stack": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.2.0.tgz",
+			"integrity": "sha512-TyUIUJgdFnCISzG5zu3291TAsE77ddchd0bepon1VVQrKLGKFED4iXFEDQ24mIPdPBbyE16PK3F8MYE1CmcBEQ==",
+			"dependencies": {
+				"escape-string-regexp": "5.0.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/clean-stack/node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/cli-cursor": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
@@ -3014,6 +3657,80 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cli-highlight": {
+			"version": "2.1.11",
+			"resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+			"integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+			"dependencies": {
+				"chalk": "^4.0.0",
+				"highlight.js": "^10.7.1",
+				"mz": "^2.4.0",
+				"parse5": "^5.1.1",
+				"parse5-htmlparser2-tree-adapter": "^6.0.0",
+				"yargs": "^16.0.0"
+			},
+			"bin": {
+				"highlight": "bin/highlight"
+			},
+			"engines": {
+				"node": ">=8.0.0",
+				"npm": ">=5.0.0"
+			}
+		},
+		"node_modules/cli-highlight/node_modules/cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"node_modules/cli-highlight/node_modules/parse5": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+			"integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
+		},
+		"node_modules/cli-highlight/node_modules/yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/cli-highlight/node_modules/yargs-parser": {
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/cli-table3": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+			"integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+			"dependencies": {
+				"string-width": "^4.2.0"
+			},
+			"engines": {
+				"node": "10.* || >= 12.*"
+			},
+			"optionalDependencies": {
+				"@colors/colors": "1.5.0"
 			}
 		},
 		"node_modules/cli-truncate": {
@@ -3158,6 +3875,20 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
 		},
+		"node_modules/config-chain": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+			"integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+			"dependencies": {
+				"ini": "^1.3.4",
+				"proto-list": "~1.2.1"
+			}
+		},
+		"node_modules/config-chain/node_modules/ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+		},
 		"node_modules/conventional-changelog-angular": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
@@ -3180,6 +3911,44 @@
 				"node": ">=16"
 			}
 		},
+		"node_modules/conventional-changelog-writer": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-7.0.1.tgz",
+			"integrity": "sha512-Uo+R9neH3r/foIvQ0MKcsXkX642hdm9odUp7TqgFS7BsalTcjzRlIfWZrZR1gbxOozKucaKt5KAbjW8J8xRSmA==",
+			"dependencies": {
+				"conventional-commits-filter": "^4.0.0",
+				"handlebars": "^4.7.7",
+				"json-stringify-safe": "^5.0.1",
+				"meow": "^12.0.1",
+				"semver": "^7.5.2",
+				"split2": "^4.0.0"
+			},
+			"bin": {
+				"conventional-changelog-writer": "cli.mjs"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/conventional-changelog-writer/node_modules/semver": {
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/conventional-commits-filter": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-4.0.0.tgz",
+			"integrity": "sha512-rnpnibcSOdFcdclpFwWa+pPlZJhXE7l+XK04zxhbWrhgpR96h33QLz8hITTXbcYICxVr3HZFtbtUAQ+4LdBo9A==",
+			"engines": {
+				"node": ">=16"
+			}
+		},
 		"node_modules/conventional-commits-parser": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz",
@@ -3197,10 +3966,26 @@
 				"node": ">=16"
 			}
 		},
+		"node_modules/convert-hrtime": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+			"integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
+		},
+		"node_modules/core-util-is": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
 		},
 		"node_modules/cosmiconfig": {
 			"version": "9.0.0",
@@ -3292,6 +4077,31 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/crypto-random-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+			"integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+			"dependencies": {
+				"type-fest": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/crypto-random-string/node_modules/type-fest": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/cssom": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
@@ -3337,6 +4147,54 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/data-view-buffer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
+			"integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+			"dependencies": {
+				"call-bind": "^1.0.6",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/data-view-byte-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
+			"integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/data-view-byte-offset": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
+			"integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+			"dependencies": {
+				"call-bind": "^1.0.6",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/debug": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -3371,6 +4229,14 @@
 				}
 			}
 		},
+		"node_modules/deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3392,6 +4258,22 @@
 				"es-define-property": "^1.0.0",
 				"es-errors": "^1.3.0",
 				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/define-properties": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+			"dependencies": {
+				"define-data-property": "^1.0.1",
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -3469,6 +4351,14 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/duplexer2": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+			"integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+			"dependencies": {
+				"readable-stream": "^2.0.2"
+			}
+		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.4.603",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.603.tgz",
@@ -3490,6 +4380,11 @@
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
 		},
+		"node_modules/emojilib": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+			"integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="
+		},
 		"node_modules/entities": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -3499,6 +4394,142 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/env-ci": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/env-ci/-/env-ci-11.0.0.tgz",
+			"integrity": "sha512-apikxMgkipkgTvMdRT9MNqWx5VLOci79F4VBd7Op/7OPjjoanjdAvn6fglMCCEf/1bAh8eOiuEVCUs4V3qP3nQ==",
+			"dependencies": {
+				"execa": "^8.0.0",
+				"java-properties": "^1.0.2"
+			},
+			"engines": {
+				"node": "^18.17 || >=20.6.1"
+			}
+		},
+		"node_modules/env-ci/node_modules/execa": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+			"integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^8.0.1",
+				"human-signals": "^5.0.0",
+				"is-stream": "^3.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^5.1.0",
+				"onetime": "^6.0.0",
+				"signal-exit": "^4.1.0",
+				"strip-final-newline": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=16.17"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/env-ci/node_modules/get-stream": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+			"integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/env-ci/node_modules/human-signals": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+			"integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+			"engines": {
+				"node": ">=16.17.0"
+			}
+		},
+		"node_modules/env-ci/node_modules/is-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+			"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/env-ci/node_modules/mimic-fn": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+			"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/env-ci/node_modules/npm-run-path": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+			"integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+			"dependencies": {
+				"path-key": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/env-ci/node_modules/onetime": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+			"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+			"dependencies": {
+				"mimic-fn": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/env-ci/node_modules/path-key": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/env-ci/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/env-ci/node_modules/strip-final-newline": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+			"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/env-paths": {
@@ -3515,6 +4546,65 @@
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 			"dependencies": {
 				"is-arrayish": "^0.2.1"
+			}
+		},
+		"node_modules/es-abstract": {
+			"version": "1.23.3",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
+			"integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
+			"dependencies": {
+				"array-buffer-byte-length": "^1.0.1",
+				"arraybuffer.prototype.slice": "^1.0.3",
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.7",
+				"data-view-buffer": "^1.0.1",
+				"data-view-byte-length": "^1.0.1",
+				"data-view-byte-offset": "^1.0.0",
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0",
+				"es-set-tostringtag": "^2.0.3",
+				"es-to-primitive": "^1.2.1",
+				"function.prototype.name": "^1.1.6",
+				"get-intrinsic": "^1.2.4",
+				"get-symbol-description": "^1.0.2",
+				"globalthis": "^1.0.3",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2",
+				"has-proto": "^1.0.3",
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.2",
+				"internal-slot": "^1.0.7",
+				"is-array-buffer": "^3.0.4",
+				"is-callable": "^1.2.7",
+				"is-data-view": "^1.0.1",
+				"is-negative-zero": "^2.0.3",
+				"is-regex": "^1.1.4",
+				"is-shared-array-buffer": "^1.0.3",
+				"is-string": "^1.0.7",
+				"is-typed-array": "^1.1.13",
+				"is-weakref": "^1.0.2",
+				"object-inspect": "^1.13.1",
+				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.5",
+				"regexp.prototype.flags": "^1.5.2",
+				"safe-array-concat": "^1.1.2",
+				"safe-regex-test": "^1.0.3",
+				"string.prototype.trim": "^1.2.9",
+				"string.prototype.trimend": "^1.0.8",
+				"string.prototype.trimstart": "^1.0.8",
+				"typed-array-buffer": "^1.0.2",
+				"typed-array-byte-length": "^1.0.1",
+				"typed-array-byte-offset": "^1.0.2",
+				"typed-array-length": "^1.0.6",
+				"unbox-primitive": "^1.0.2",
+				"which-typed-array": "^1.1.15"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/es-define-property": {
@@ -3534,6 +4624,46 @@
 			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+			"integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-set-tostringtag": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
+			"integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+			"dependencies": {
+				"get-intrinsic": "^1.2.4",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-to-primitive": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+			"dependencies": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/escalade": {
@@ -3920,6 +5050,20 @@
 				"bser": "2.1.1"
 			}
 		},
+		"node_modules/figures": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+			"integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+			"dependencies": {
+				"is-unicode-supported": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -3954,6 +5098,32 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/find-up-simple": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.0.tgz",
+			"integrity": "sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-versions": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/find-versions/-/find-versions-6.0.0.tgz",
+			"integrity": "sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==",
+			"dependencies": {
+				"semver-regex": "^4.0.5",
+				"super-regex": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/flat-cache": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -3972,6 +5142,14 @@
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
 			"integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
 		},
+		"node_modules/for-each": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+			"dependencies": {
+				"is-callable": "^1.1.3"
+			}
+		},
 		"node_modules/form-data": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -3983,6 +5161,36 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/from2": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+			"integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
+			"dependencies": {
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0"
+			}
+		},
+		"node_modules/fs-extra": {
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+			"integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
+		"node_modules/fs-extra/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"engines": {
+				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -4007,6 +5215,42 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/function-timeout": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
+			"integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/function.prototype.name": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+			"integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"functions-have-names": "^1.2.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/functions-have-names": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -4073,6 +5317,43 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-symbol-description": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
+			"integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+			"dependencies": {
+				"call-bind": "^1.0.5",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/git-log-parser": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.0.tgz",
+			"integrity": "sha512-rnCVNfkTL8tdNryFuaY0fYiBWEBcgF748O6ZI61rslBvr2o7U65c2/6npCRqH40vuAhtgtDiqLTJjBVdrejCzA==",
+			"dependencies": {
+				"argv-formatter": "~1.0.0",
+				"spawn-error-forwarder": "~1.0.0",
+				"split2": "~1.0.0",
+				"stream-combiner2": "~1.1.1",
+				"through2": "~2.0.0",
+				"traverse": "~0.6.6"
+			}
+		},
+		"node_modules/git-log-parser/node_modules/split2": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
+			"integrity": "sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg==",
+			"dependencies": {
+				"through2": "~2.0.0"
 			}
 		},
 		"node_modules/git-raw-commits": {
@@ -4143,6 +5424,21 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/globalthis": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+			"integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+			"dependencies": {
+				"define-properties": "^1.2.1",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/globby": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -4183,6 +5479,26 @@
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
 		},
+		"node_modules/handlebars": {
+			"version": "4.7.8",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+			"dependencies": {
+				"minimist": "^1.2.5",
+				"neo-async": "^2.6.2",
+				"source-map": "^0.6.1",
+				"wordwrap": "^1.0.0"
+			},
+			"bin": {
+				"handlebars": "bin/handlebars"
+			},
+			"engines": {
+				"node": ">=0.4.7"
+			},
+			"optionalDependencies": {
+				"uglify-js": "^3.1.4"
+			}
+		},
 		"node_modules/has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -4192,6 +5508,14 @@
 			},
 			"engines": {
 				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/has-bigints": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/has-flag": {
@@ -4258,6 +5582,44 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/highlight.js": {
+			"version": "10.7.3",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/hook-std": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/hook-std/-/hook-std-3.0.0.tgz",
+			"integrity": "sha512-jHRQzjSDzMtFy34AGj1DN+vq54WVuhSvKgrHf0OMiFQTwDD4L/qqofVEWjLOBMTn5+lCD3fPg32W9yOfnEJTTw==",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/hosted-git-info": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+			"dependencies": {
+				"lru-cache": "^10.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/hosted-git-info/node_modules/lru-cache": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+			"integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
+			"engines": {
+				"node": "14 || >=16.14"
 			}
 		},
 		"node_modules/html-encoding-sniffer": {
@@ -4366,6 +5728,18 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/import-from-esm": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-1.3.4.tgz",
+			"integrity": "sha512-7EyUlPFC0HOlBDpUFGfYstsU7XHxZJKAAMzCT8wZ0hMW7b+hG51LIKTDcsgtz8Pu6YC0HqRVbX+rVUtsGMUKvg==",
+			"dependencies": {
+				"debug": "^4.3.4",
+				"import-meta-resolve": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=16.20"
+			}
+		},
 		"node_modules/import-local": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
@@ -4401,6 +5775,28 @@
 				"node": ">=0.8.19"
 			}
 		},
+		"node_modules/indent-string": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/index-to-position": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-0.1.2.tgz",
+			"integrity": "sha512-MWDKS3AS1bGCHLBA2VLImJz42f7bJh8wQsTGCzI3j519/CASStoDONUBVz2I/VID0MpiX3SGSnbOD2xUalbE5g==",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4423,10 +5819,90 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
+		"node_modules/internal-slot": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
+			"integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"hasown": "^2.0.0",
+				"side-channel": "^1.0.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/into-stream": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-7.0.0.tgz",
+			"integrity": "sha512-2dYz766i9HprMBasCMvHMuazJ7u4WzhJwo5kb3iPSiW/iRYV6uPari3zHoqZlnuaR7V1bEiNMxikhp37rdBXbw==",
+			"dependencies": {
+				"from2": "^2.3.0",
+				"p-is-promise": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-array-buffer": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+			"integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
+		},
+		"node_modules/is-bigint": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+			"dependencies": {
+				"has-bigints": "^1.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-boolean-object": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+			"integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-callable": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/is-core-module": {
 			"version": "2.12.1",
@@ -4434,6 +5910,34 @@
 			"integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
 			"dependencies": {
 				"has": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-data-view": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
+			"integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+			"dependencies": {
+				"is-typed-array": "^1.1.13"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-date-object": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+			"integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -4494,12 +5998,37 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-negative-zero": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+			"integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"engines": {
 				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/is-number-object": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+			"integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-obj": {
@@ -4516,6 +6045,17 @@
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/is-plain-obj": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+			"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-potential-custom-element-name": {
@@ -4538,6 +6078,20 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-shared-array-buffer": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
+			"integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+			"dependencies": {
+				"call-bind": "^1.0.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/is-stream": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -4547,6 +6101,34 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-string": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+			"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+			"dependencies": {
+				"has-tostringtag": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-symbol": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+			"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+			"dependencies": {
+				"has-symbols": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-text-path": {
@@ -4560,10 +6142,66 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/is-typed-array": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
+			"integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+			"dependencies": {
+				"which-typed-array": "^1.1.14"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-unicode-supported": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.0.0.tgz",
+			"integrity": "sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q==",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-weakref": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+			"integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+			"dependencies": {
+				"call-bind": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+		},
+		"node_modules/issue-parser": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.0.tgz",
+			"integrity": "sha512-jgAw78HO3gs9UrKqJNQvfDj9Ouy8Mhu40fbEJ8yXff4MW8+/Fcn9iFjyWUQ6SKbX8ipPk3X5A3AyfYHRu6uVLw==",
+			"dependencies": {
+				"lodash.capitalize": "^4.2.1",
+				"lodash.escaperegexp": "^4.1.2",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.uniqby": "^4.7.0"
+			},
+			"engines": {
+				"node": "^18.17 || >=20.6.1"
+			}
 		},
 		"node_modules/istanbul-lib-coverage": {
 			"version": "3.2.2",
@@ -4624,6 +6262,14 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/java-properties": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
+			"integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
+			"engines": {
+				"node": ">= 0.6.0"
 			}
 		},
 		"node_modules/jest": {
@@ -5294,6 +6940,11 @@
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
 			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
 		},
+		"node_modules/json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+		},
 		"node_modules/json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -5308,6 +6959,11 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
+		},
+		"node_modules/json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
 		},
 		"node_modules/json5": {
 			"version": "2.2.3",
@@ -5324,6 +6980,25 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
 			"integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA=="
+		},
+		"node_modules/jsonfile": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/jsonfile/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
 		},
 		"node_modules/jsonparse": {
 			"version": "1.3.1",
@@ -5647,6 +7322,40 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
+		"node_modules/load-json-file": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+			"dependencies": {
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
+				"strip-bom": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/load-json-file/node_modules/parse-json": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+			"dependencies": {
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/load-json-file/node_modules/strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/locate-path": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -5658,15 +7367,35 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/lodash-es": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+			"integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+		},
 		"node_modules/lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
 			"integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
 		},
+		"node_modules/lodash.capitalize": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+			"integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw=="
+		},
+		"node_modules/lodash.escaperegexp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="
+		},
 		"node_modules/lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
 			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+		},
+		"node_modules/lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
 		},
 		"node_modules/lodash.kebabcase": {
 			"version": "4.1.1",
@@ -5697,6 +7426,11 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
 			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
+		},
+		"node_modules/lodash.uniqby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+			"integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww=="
 		},
 		"node_modules/lodash.upperfirst": {
 			"version": "4.3.1",
@@ -5908,6 +7642,58 @@
 				"tmpl": "1.0.5"
 			}
 		},
+		"node_modules/marked": {
+			"version": "12.0.2",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+			"integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/marked-terminal": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.0.0.tgz",
+			"integrity": "sha512-sNEx8nn9Ktcm6pL0TnRz8tnXq/mSS0Q1FRSwJOAqw4lAB4l49UeDf85Gm1n9RPFm5qurCPjwi1StAQT2XExhZw==",
+			"dependencies": {
+				"ansi-escapes": "^6.2.0",
+				"chalk": "^5.3.0",
+				"cli-highlight": "^2.1.11",
+				"cli-table3": "^0.6.3",
+				"node-emoji": "^2.1.3",
+				"supports-hyperlinks": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"marked": ">=1 <13"
+			}
+		},
+		"node_modules/marked-terminal/node_modules/ansi-escapes": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
+			"integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/marked-terminal/node_modules/chalk": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
 		"node_modules/memorystream": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
@@ -5950,6 +7736,20 @@
 			},
 			"engines": {
 				"node": ">=8.6"
+			}
+		},
+		"node_modules/mime": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-4.0.3.tgz",
+			"integrity": "sha512-KgUb15Oorc0NEKPbvfa0wRU+PItIEZmiv+pyAO2i0oTIVTJhlzMclU7w4RXWQrSOVH5ax/p/CkIO7KI4OyFJTQ==",
+			"funding": [
+				"https://github.com/sponsors/broofa"
+			],
+			"bin": {
+				"mime": "bin/cli.js"
+			},
+			"engines": {
+				"node": ">=16"
 			}
 		},
 		"node_modules/mime-db": {
@@ -6003,10 +7803,44 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
+		"node_modules/mz": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+			"dependencies": {
+				"any-promise": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"thenify-all": "^1.0.0"
+			}
+		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
+		},
+		"node_modules/neo-async": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+		},
+		"node_modules/nerf-dart": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
+			"integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g=="
+		},
+		"node_modules/node-emoji": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.1.3.tgz",
+			"integrity": "sha512-E2WEOVsgs7O16zsURJ/eH8BqhF029wGpEOnv7Urwdo2wmQanOACwJQh0devF9D9RhoZru0+9JXIS0dBXIAz+lA==",
+			"dependencies": {
+				"@sindresorhus/is": "^4.6.0",
+				"char-regex": "^1.0.2",
+				"emojilib": "^2.4.0",
+				"skin-tone": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/node-int64": {
 			"version": "0.4.0",
@@ -6018,12 +7852,207 @@
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
 			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
 		},
+		"node_modules/normalize-package-data": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.1.tgz",
+			"integrity": "sha512-6rvCfeRW+OEZagAB4lMLSNuTNYZWLVtKccK79VSTf//yTY5VOCgcpH80O+bZK8Neps7pUnd5G+QlMg1yV/2iZQ==",
+			"dependencies": {
+				"hosted-git-info": "^7.0.0",
+				"is-core-module": "^2.8.1",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/normalize-package-data/node_modules/semver": {
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/normalize-url": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.1.tgz",
+			"integrity": "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==",
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm": {
+			"version": "10.8.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-10.8.0.tgz",
+			"integrity": "sha512-wh93uRczgp7HDnPMiLXcCkv2hagdJS0zJ9KT/31d0FoXP02+qgN2AOwpaW85fxRWkinl2rELfPw+CjBXW48/jQ==",
+			"bundleDependencies": [
+				"@isaacs/string-locale-compare",
+				"@npmcli/arborist",
+				"@npmcli/config",
+				"@npmcli/fs",
+				"@npmcli/map-workspaces",
+				"@npmcli/package-json",
+				"@npmcli/promise-spawn",
+				"@npmcli/redact",
+				"@npmcli/run-script",
+				"@sigstore/tuf",
+				"abbrev",
+				"archy",
+				"cacache",
+				"chalk",
+				"ci-info",
+				"cli-columns",
+				"fastest-levenshtein",
+				"fs-minipass",
+				"glob",
+				"graceful-fs",
+				"hosted-git-info",
+				"ini",
+				"init-package-json",
+				"is-cidr",
+				"json-parse-even-better-errors",
+				"libnpmaccess",
+				"libnpmdiff",
+				"libnpmexec",
+				"libnpmfund",
+				"libnpmhook",
+				"libnpmorg",
+				"libnpmpack",
+				"libnpmpublish",
+				"libnpmsearch",
+				"libnpmteam",
+				"libnpmversion",
+				"make-fetch-happen",
+				"minimatch",
+				"minipass",
+				"minipass-pipeline",
+				"ms",
+				"node-gyp",
+				"nopt",
+				"normalize-package-data",
+				"npm-audit-report",
+				"npm-install-checks",
+				"npm-package-arg",
+				"npm-pick-manifest",
+				"npm-profile",
+				"npm-registry-fetch",
+				"npm-user-validate",
+				"p-map",
+				"pacote",
+				"parse-conflict-json",
+				"proc-log",
+				"qrcode-terminal",
+				"read",
+				"semver",
+				"spdx-expression-parse",
+				"ssri",
+				"supports-color",
+				"tar",
+				"text-table",
+				"tiny-relative-date",
+				"treeverse",
+				"validate-npm-package-name",
+				"which",
+				"write-file-atomic"
+			],
+			"workspaces": [
+				"docs",
+				"smoke-tests",
+				"mock-globals",
+				"mock-registry",
+				"workspaces/*"
+			],
+			"dependencies": {
+				"@isaacs/string-locale-compare": "^1.1.0",
+				"@npmcli/arborist": "^7.5.2",
+				"@npmcli/config": "^8.3.2",
+				"@npmcli/fs": "^3.1.1",
+				"@npmcli/map-workspaces": "^3.0.6",
+				"@npmcli/package-json": "^5.1.0",
+				"@npmcli/promise-spawn": "^7.0.2",
+				"@npmcli/redact": "^2.0.0",
+				"@npmcli/run-script": "^8.1.0",
+				"@sigstore/tuf": "^2.3.3",
+				"abbrev": "^2.0.0",
+				"archy": "~1.0.0",
+				"cacache": "^18.0.3",
+				"chalk": "^5.3.0",
+				"ci-info": "^4.0.0",
+				"cli-columns": "^4.0.0",
+				"fastest-levenshtein": "^1.0.16",
+				"fs-minipass": "^3.0.3",
+				"glob": "^10.3.15",
+				"graceful-fs": "^4.2.11",
+				"hosted-git-info": "^7.0.2",
+				"ini": "^4.1.2",
+				"init-package-json": "^6.0.3",
+				"is-cidr": "^5.0.5",
+				"json-parse-even-better-errors": "^3.0.2",
+				"libnpmaccess": "^8.0.6",
+				"libnpmdiff": "^6.1.2",
+				"libnpmexec": "^8.1.1",
+				"libnpmfund": "^5.0.10",
+				"libnpmhook": "^10.0.5",
+				"libnpmorg": "^6.0.6",
+				"libnpmpack": "^7.0.2",
+				"libnpmpublish": "^9.0.8",
+				"libnpmsearch": "^7.0.5",
+				"libnpmteam": "^6.0.5",
+				"libnpmversion": "^6.0.2",
+				"make-fetch-happen": "^13.0.1",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.1",
+				"minipass-pipeline": "^1.2.4",
+				"ms": "^2.1.2",
+				"node-gyp": "^10.1.0",
+				"nopt": "^7.2.1",
+				"normalize-package-data": "^6.0.1",
+				"npm-audit-report": "^5.0.0",
+				"npm-install-checks": "^6.3.0",
+				"npm-package-arg": "^11.0.2",
+				"npm-pick-manifest": "^9.0.1",
+				"npm-profile": "^10.0.0",
+				"npm-registry-fetch": "^17.0.1",
+				"npm-user-validate": "^2.0.1",
+				"p-map": "^4.0.0",
+				"pacote": "^18.0.6",
+				"parse-conflict-json": "^3.0.1",
+				"proc-log": "^4.2.0",
+				"qrcode-terminal": "^0.12.0",
+				"read": "^3.0.1",
+				"semver": "^7.6.2",
+				"spdx-expression-parse": "^4.0.0",
+				"ssri": "^10.0.6",
+				"supports-color": "^9.4.0",
+				"tar": "^6.2.1",
+				"text-table": "~0.2.0",
+				"tiny-relative-date": "^1.3.0",
+				"treeverse": "^3.0.0",
+				"validate-npm-package-name": "^5.0.1",
+				"which": "^4.0.0",
+				"write-file-atomic": "^5.0.1"
+			},
+			"bin": {
+				"npm": "bin/npm-cli.js",
+				"npx": "bin/npx-cli.js"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
 			}
 		},
 		"node_modules/npm-normalize-package-bin": {
@@ -6102,6 +8131,2248 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/npm/node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+			"version": "6.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
+			"version": "5.1.2",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/@isaacs/string-locale-compare": {
+			"version": "1.1.0",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/@npmcli/agent": {
+			"version": "2.2.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.1",
+				"lru-cache": "^10.0.1",
+				"socks-proxy-agent": "^8.0.3"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/arborist": {
+			"version": "7.5.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@isaacs/string-locale-compare": "^1.1.0",
+				"@npmcli/fs": "^3.1.1",
+				"@npmcli/installed-package-contents": "^2.1.0",
+				"@npmcli/map-workspaces": "^3.0.2",
+				"@npmcli/metavuln-calculator": "^7.1.1",
+				"@npmcli/name-from-folder": "^2.0.0",
+				"@npmcli/node-gyp": "^3.0.0",
+				"@npmcli/package-json": "^5.1.0",
+				"@npmcli/query": "^3.1.0",
+				"@npmcli/redact": "^2.0.0",
+				"@npmcli/run-script": "^8.1.0",
+				"bin-links": "^4.0.4",
+				"cacache": "^18.0.3",
+				"common-ancestor-path": "^1.0.1",
+				"hosted-git-info": "^7.0.2",
+				"json-parse-even-better-errors": "^3.0.2",
+				"json-stringify-nice": "^1.1.4",
+				"lru-cache": "^10.2.2",
+				"minimatch": "^9.0.4",
+				"nopt": "^7.2.1",
+				"npm-install-checks": "^6.2.0",
+				"npm-package-arg": "^11.0.2",
+				"npm-pick-manifest": "^9.0.1",
+				"npm-registry-fetch": "^17.0.1",
+				"pacote": "^18.0.6",
+				"parse-conflict-json": "^3.0.0",
+				"proc-log": "^4.2.0",
+				"proggy": "^2.0.0",
+				"promise-all-reject-late": "^1.0.0",
+				"promise-call-limit": "^3.0.1",
+				"read-package-json-fast": "^3.0.2",
+				"semver": "^7.3.7",
+				"ssri": "^10.0.6",
+				"treeverse": "^3.0.0",
+				"walk-up-path": "^3.0.1"
+			},
+			"bin": {
+				"arborist": "bin/index.js"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/config": {
+			"version": "8.3.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/map-workspaces": "^3.0.2",
+				"ci-info": "^4.0.0",
+				"ini": "^4.1.2",
+				"nopt": "^7.2.1",
+				"proc-log": "^4.2.0",
+				"read-package-json-fast": "^3.0.2",
+				"semver": "^7.3.5",
+				"walk-up-path": "^3.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/fs": {
+			"version": "3.1.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/git": {
+			"version": "5.0.7",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/promise-spawn": "^7.0.0",
+				"lru-cache": "^10.0.1",
+				"npm-pick-manifest": "^9.0.0",
+				"proc-log": "^4.0.0",
+				"promise-inflight": "^1.0.1",
+				"promise-retry": "^2.0.1",
+				"semver": "^7.3.5",
+				"which": "^4.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/installed-package-contents": {
+			"version": "2.1.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-bundled": "^3.0.0",
+				"npm-normalize-package-bin": "^3.0.0"
+			},
+			"bin": {
+				"installed-package-contents": "bin/index.js"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/map-workspaces": {
+			"version": "3.0.6",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/name-from-folder": "^2.0.0",
+				"glob": "^10.2.2",
+				"minimatch": "^9.0.0",
+				"read-package-json-fast": "^3.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
+			"version": "7.1.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"cacache": "^18.0.0",
+				"json-parse-even-better-errors": "^3.0.0",
+				"pacote": "^18.0.0",
+				"proc-log": "^4.1.0",
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/name-from-folder": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/node-gyp": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/package-json": {
+			"version": "5.1.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/git": "^5.0.0",
+				"glob": "^10.2.2",
+				"hosted-git-info": "^7.0.0",
+				"json-parse-even-better-errors": "^3.0.0",
+				"normalize-package-data": "^6.0.0",
+				"proc-log": "^4.0.0",
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/promise-spawn": {
+			"version": "7.0.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"which": "^4.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/query": {
+			"version": "3.1.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"postcss-selector-parser": "^6.0.10"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/redact": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/run-script": {
+			"version": "8.1.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/node-gyp": "^3.0.0",
+				"@npmcli/package-json": "^5.0.0",
+				"@npmcli/promise-spawn": "^7.0.0",
+				"node-gyp": "^10.0.0",
+				"proc-log": "^4.0.0",
+				"which": "^4.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/bundle": {
+			"version": "2.3.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/protobuf-specs": "^0.3.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/core": {
+			"version": "1.1.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/protobuf-specs": {
+			"version": "0.3.2",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/sign": {
+			"version": "2.3.1",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/bundle": "^2.3.0",
+				"@sigstore/core": "^1.0.0",
+				"@sigstore/protobuf-specs": "^0.3.1",
+				"make-fetch-happen": "^13.0.1",
+				"proc-log": "^4.2.0",
+				"promise-retry": "^2.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/tuf": {
+			"version": "2.3.3",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/protobuf-specs": "^0.3.0",
+				"tuf-js": "^2.2.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/verify": {
+			"version": "1.2.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/bundle": "^2.3.1",
+				"@sigstore/core": "^1.1.0",
+				"@sigstore/protobuf-specs": "^0.3.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@tufjs/canonical-json": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@tufjs/models": {
+			"version": "2.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"@tufjs/canonical-json": "2.0.0",
+				"minimatch": "^9.0.4"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/abbrev": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/agent-base": {
+			"version": "7.1.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/npm/node_modules/aggregate-error": {
+			"version": "3.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/ansi-styles": {
+			"version": "6.2.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/aproba": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/archy": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/bin-links": {
+			"version": "4.0.4",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"cmd-shim": "^6.0.0",
+				"npm-normalize-package-bin": "^3.0.0",
+				"read-cmd-shim": "^4.0.0",
+				"write-file-atomic": "^5.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/binary-extensions": {
+			"version": "2.3.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/cacache": {
+			"version": "18.0.3",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/fs": "^3.1.0",
+				"fs-minipass": "^3.0.0",
+				"glob": "^10.2.2",
+				"lru-cache": "^10.0.1",
+				"minipass": "^7.0.3",
+				"minipass-collect": "^2.0.1",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.4",
+				"p-map": "^4.0.0",
+				"ssri": "^10.0.0",
+				"tar": "^6.1.11",
+				"unique-filename": "^3.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/chalk": {
+			"version": "5.3.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/chownr": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/npm/node_modules/ci-info": {
+			"version": "4.0.0",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/cidr-regex": {
+			"version": "4.0.5",
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"ip-regex": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/npm/node_modules/clean-stack": {
+			"version": "2.2.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/npm/node_modules/cli-columns": {
+			"version": "4.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/npm/node_modules/cmd-shim": {
+			"version": "6.0.3",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/color-convert": {
+			"version": "2.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/color-name": {
+			"version": "1.1.4",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/common-ancestor-path": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/cross-spawn": {
+			"version": "7.0.3",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/npm/node_modules/cross-spawn/node_modules/which": {
+			"version": "2.0.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/npm/node_modules/cssesc": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"bin": {
+				"cssesc": "bin/cssesc"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npm/node_modules/debug": {
+			"version": "4.3.4",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/npm/node_modules/debug/node_modules/ms": {
+			"version": "2.1.2",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/diff": {
+			"version": "5.2.0",
+			"inBundle": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/npm/node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/encoding": {
+			"version": "0.1.13",
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"iconv-lite": "^0.6.2"
+			}
+		},
+		"node_modules/npm/node_modules/env-paths": {
+			"version": "2.2.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/npm/node_modules/err-code": {
+			"version": "2.0.3",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/exponential-backoff": {
+			"version": "3.1.1",
+			"inBundle": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/npm/node_modules/fastest-levenshtein": {
+			"version": "1.0.16",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.9.1"
+			}
+		},
+		"node_modules/npm/node_modules/foreground-child": {
+			"version": "3.1.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.0",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/fs-minipass": {
+			"version": "3.0.3",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.3"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/function-bind": {
+			"version": "1.1.2",
+			"inBundle": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/npm/node_modules/glob": {
+			"version": "10.3.15",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^2.3.6",
+				"minimatch": "^9.0.1",
+				"minipass": "^7.0.4",
+				"path-scurry": "^1.11.0"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/hasown": {
+			"version": "2.0.2",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/npm/node_modules/hosted-git-info": {
+			"version": "7.0.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^10.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/http-cache-semantics": {
+			"version": "4.1.1",
+			"inBundle": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/npm/node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/npm/node_modules/https-proxy-agent": {
+			"version": "7.0.4",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.0.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/npm/node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npm/node_modules/ignore-walk": {
+			"version": "6.0.5",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minimatch": "^9.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/imurmurhash": {
+			"version": "0.1.4",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.19"
+			}
+		},
+		"node_modules/npm/node_modules/indent-string": {
+			"version": "4.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/ini": {
+			"version": "4.1.2",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/init-package-json": {
+			"version": "6.0.3",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/package-json": "^5.0.0",
+				"npm-package-arg": "^11.0.0",
+				"promzard": "^1.0.0",
+				"read": "^3.0.1",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4",
+				"validate-npm-package-name": "^5.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/ip-address": {
+			"version": "9.0.5",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"jsbn": "1.1.0",
+				"sprintf-js": "^1.1.3"
+			},
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/npm/node_modules/ip-regex": {
+			"version": "5.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm/node_modules/is-cidr": {
+			"version": "5.0.5",
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"cidr-regex": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/npm/node_modules/is-core-module": {
+			"version": "2.13.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"hasown": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/npm/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/is-lambda": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/isexe": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/jackspeak": {
+			"version": "2.3.6",
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/npm/node_modules/jsbn": {
+			"version": "1.1.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/json-parse-even-better-errors": {
+			"version": "3.0.2",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/json-stringify-nice": {
+			"version": "1.1.4",
+			"inBundle": true,
+			"license": "ISC",
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/jsonparse": {
+			"version": "1.3.1",
+			"engines": [
+				"node >= 0.2.0"
+			],
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/just-diff": {
+			"version": "6.0.2",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/just-diff-apply": {
+			"version": "5.5.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/libnpmaccess": {
+			"version": "8.0.6",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-package-arg": "^11.0.2",
+				"npm-registry-fetch": "^17.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmdiff": {
+			"version": "6.1.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/arborist": "^7.5.2",
+				"@npmcli/installed-package-contents": "^2.1.0",
+				"binary-extensions": "^2.3.0",
+				"diff": "^5.1.0",
+				"minimatch": "^9.0.4",
+				"npm-package-arg": "^11.0.2",
+				"pacote": "^18.0.6",
+				"tar": "^6.2.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmexec": {
+			"version": "8.1.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/arborist": "^7.5.2",
+				"@npmcli/run-script": "^8.1.0",
+				"ci-info": "^4.0.0",
+				"npm-package-arg": "^11.0.2",
+				"pacote": "^18.0.6",
+				"proc-log": "^4.2.0",
+				"read": "^3.0.1",
+				"read-package-json-fast": "^3.0.2",
+				"semver": "^7.3.7",
+				"walk-up-path": "^3.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmfund": {
+			"version": "5.0.10",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/arborist": "^7.5.2"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmhook": {
+			"version": "10.0.5",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"aproba": "^2.0.0",
+				"npm-registry-fetch": "^17.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmorg": {
+			"version": "6.0.6",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"aproba": "^2.0.0",
+				"npm-registry-fetch": "^17.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmpack": {
+			"version": "7.0.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/arborist": "^7.5.2",
+				"@npmcli/run-script": "^8.1.0",
+				"npm-package-arg": "^11.0.2",
+				"pacote": "^18.0.6"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmpublish": {
+			"version": "9.0.8",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"ci-info": "^4.0.0",
+				"normalize-package-data": "^6.0.1",
+				"npm-package-arg": "^11.0.2",
+				"npm-registry-fetch": "^17.0.1",
+				"proc-log": "^4.2.0",
+				"semver": "^7.3.7",
+				"sigstore": "^2.2.0",
+				"ssri": "^10.0.6"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmsearch": {
+			"version": "7.0.5",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-registry-fetch": "^17.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmteam": {
+			"version": "6.0.5",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"aproba": "^2.0.0",
+				"npm-registry-fetch": "^17.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmversion": {
+			"version": "6.0.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/git": "^5.0.7",
+				"@npmcli/run-script": "^8.1.0",
+				"json-parse-even-better-errors": "^3.0.2",
+				"proc-log": "^4.2.0",
+				"semver": "^7.3.7"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/lru-cache": {
+			"version": "10.2.2",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "14 || >=16.14"
+			}
+		},
+		"node_modules/npm/node_modules/make-fetch-happen": {
+			"version": "13.0.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/agent": "^2.0.0",
+				"cacache": "^18.0.0",
+				"http-cache-semantics": "^4.1.1",
+				"is-lambda": "^1.0.1",
+				"minipass": "^7.0.2",
+				"minipass-fetch": "^3.0.0",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.4",
+				"negotiator": "^0.6.3",
+				"proc-log": "^4.2.0",
+				"promise-retry": "^2.0.1",
+				"ssri": "^10.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/minimatch": {
+			"version": "9.0.4",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/minipass": {
+			"version": "7.1.1",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-collect": {
+			"version": "2.0.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.3"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-fetch": {
+			"version": "3.0.5",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^7.0.3",
+				"minipass-sized": "^1.0.3",
+				"minizlib": "^2.1.2"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			},
+			"optionalDependencies": {
+				"encoding": "^0.1.13"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-flush": {
+			"version": "1.0.5",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
+			"version": "3.3.6",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-json-stream": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"jsonparse": "^1.3.1",
+				"minipass": "^3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-json-stream/node_modules/minipass": {
+			"version": "3.3.6",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-pipeline": {
+			"version": "1.2.4",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
+			"version": "3.3.6",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-sized": {
+			"version": "1.0.3",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
+			"version": "3.3.6",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/minizlib": {
+			"version": "2.1.2",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^3.0.0",
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/npm/node_modules/minizlib/node_modules/minipass": {
+			"version": "3.3.6",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/mkdirp": {
+			"version": "1.0.4",
+			"inBundle": true,
+			"license": "MIT",
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/npm/node_modules/ms": {
+			"version": "2.1.3",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/mute-stream": {
+			"version": "1.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/negotiator": {
+			"version": "0.6.3",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/npm/node_modules/node-gyp": {
+			"version": "10.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"env-paths": "^2.2.0",
+				"exponential-backoff": "^3.1.1",
+				"glob": "^10.3.10",
+				"graceful-fs": "^4.2.6",
+				"make-fetch-happen": "^13.0.0",
+				"nopt": "^7.0.0",
+				"proc-log": "^3.0.0",
+				"semver": "^7.3.5",
+				"tar": "^6.1.2",
+				"which": "^4.0.0"
+			},
+			"bin": {
+				"node-gyp": "bin/node-gyp.js"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/node-gyp/node_modules/proc-log": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/nopt": {
+			"version": "7.2.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"abbrev": "^2.0.0"
+			},
+			"bin": {
+				"nopt": "bin/nopt.js"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/normalize-package-data": {
+			"version": "6.0.1",
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"hosted-git-info": "^7.0.0",
+				"is-core-module": "^2.8.1",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-audit-report": {
+			"version": "5.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-bundled": {
+			"version": "3.0.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-normalize-package-bin": "^3.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-install-checks": {
+			"version": "6.3.0",
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"semver": "^7.1.1"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-normalize-package-bin": {
+			"version": "3.0.1",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-package-arg": {
+			"version": "11.0.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"hosted-git-info": "^7.0.0",
+				"proc-log": "^4.0.0",
+				"semver": "^7.3.5",
+				"validate-npm-package-name": "^5.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-packlist": {
+			"version": "8.0.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"ignore-walk": "^6.0.4"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-pick-manifest": {
+			"version": "9.0.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-install-checks": "^6.0.0",
+				"npm-normalize-package-bin": "^3.0.0",
+				"npm-package-arg": "^11.0.0",
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-profile": {
+			"version": "10.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-registry-fetch": "^17.0.1",
+				"proc-log": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-registry-fetch": {
+			"version": "17.0.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/redact": "^2.0.0",
+				"make-fetch-happen": "^13.0.0",
+				"minipass": "^7.0.2",
+				"minipass-fetch": "^3.0.0",
+				"minipass-json-stream": "^1.0.1",
+				"minizlib": "^2.1.2",
+				"npm-package-arg": "^11.0.0",
+				"proc-log": "^4.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-user-validate": {
+			"version": "2.0.1",
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/p-map": {
+			"version": "4.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"aggregate-error": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm/node_modules/pacote": {
+			"version": "18.0.6",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/git": "^5.0.0",
+				"@npmcli/installed-package-contents": "^2.0.1",
+				"@npmcli/package-json": "^5.1.0",
+				"@npmcli/promise-spawn": "^7.0.0",
+				"@npmcli/run-script": "^8.0.0",
+				"cacache": "^18.0.0",
+				"fs-minipass": "^3.0.0",
+				"minipass": "^7.0.2",
+				"npm-package-arg": "^11.0.0",
+				"npm-packlist": "^8.0.0",
+				"npm-pick-manifest": "^9.0.0",
+				"npm-registry-fetch": "^17.0.0",
+				"proc-log": "^4.0.0",
+				"promise-retry": "^2.0.1",
+				"sigstore": "^2.2.0",
+				"ssri": "^10.0.0",
+				"tar": "^6.1.11"
+			},
+			"bin": {
+				"pacote": "bin/index.js"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/parse-conflict-json": {
+			"version": "3.0.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"json-parse-even-better-errors": "^3.0.0",
+				"just-diff": "^6.0.0",
+				"just-diff-apply": "^5.2.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/path-key": {
+			"version": "3.1.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/path-scurry": {
+			"version": "1.11.1",
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/postcss-selector-parser": {
+			"version": "6.0.16",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npm/node_modules/proc-log": {
+			"version": "4.2.0",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/proggy": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/promise-all-reject-late": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "ISC",
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/promise-call-limit": {
+			"version": "3.0.1",
+			"inBundle": true,
+			"license": "ISC",
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/promise-inflight": {
+			"version": "1.0.1",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/promise-retry": {
+			"version": "2.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"err-code": "^2.0.2",
+				"retry": "^0.12.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/npm/node_modules/promzard": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"read": "^3.0.1"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/qrcode-terminal": {
+			"version": "0.12.0",
+			"inBundle": true,
+			"bin": {
+				"qrcode-terminal": "bin/qrcode-terminal.js"
+			}
+		},
+		"node_modules/npm/node_modules/read": {
+			"version": "3.0.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"mute-stream": "^1.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/read-cmd-shim": {
+			"version": "4.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/read-package-json-fast": {
+			"version": "3.0.2",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"json-parse-even-better-errors": "^3.0.0",
+				"npm-normalize-package-bin": "^3.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/retry": {
+			"version": "0.12.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/npm/node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/npm/node_modules/semver": {
+			"version": "7.6.2",
+			"inBundle": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/npm/node_modules/shebang-command": {
+			"version": "2.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/sigstore": {
+			"version": "2.3.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/bundle": "^2.3.1",
+				"@sigstore/core": "^1.0.0",
+				"@sigstore/protobuf-specs": "^0.3.1",
+				"@sigstore/sign": "^2.3.0",
+				"@sigstore/tuf": "^2.3.1",
+				"@sigstore/verify": "^1.2.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/smart-buffer": {
+			"version": "4.2.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/socks": {
+			"version": "2.8.3",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ip-address": "^9.0.5",
+				"smart-buffer": "^4.2.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/socks-proxy-agent": {
+			"version": "8.0.3",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.1",
+				"debug": "^4.3.4",
+				"socks": "^2.7.1"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/npm/node_modules/spdx-correct": {
+			"version": "3.2.0",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
+			"version": "3.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/spdx-exceptions": {
+			"version": "2.5.0",
+			"inBundle": true,
+			"license": "CC-BY-3.0"
+		},
+		"node_modules/npm/node_modules/spdx-expression-parse": {
+			"version": "4.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/spdx-license-ids": {
+			"version": "3.0.17",
+			"inBundle": true,
+			"license": "CC0-1.0"
+		},
+		"node_modules/npm/node_modules/sprintf-js": {
+			"version": "1.1.3",
+			"inBundle": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/npm/node_modules/ssri": {
+			"version": "10.0.6",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.3"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/string-width": {
+			"version": "4.2.3",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/string-width-cjs": {
+			"name": "string-width",
+			"version": "4.2.3",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
+			"version": "6.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/supports-color": {
+			"version": "9.4.0",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/tar": {
+			"version": "6.2.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"chownr": "^2.0.0",
+				"fs-minipass": "^2.0.0",
+				"minipass": "^5.0.0",
+				"minizlib": "^2.1.1",
+				"mkdirp": "^1.0.3",
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
+			"version": "2.1.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
+			"version": "3.3.6",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/tar/node_modules/minipass": {
+			"version": "5.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/text-table": {
+			"version": "0.2.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/tiny-relative-date": {
+			"version": "1.3.0",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/treeverse": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/tuf-js": {
+			"version": "2.2.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"@tufjs/models": "2.0.1",
+				"debug": "^4.3.4",
+				"make-fetch-happen": "^13.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/unique-filename": {
+			"version": "3.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"unique-slug": "^4.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/unique-slug": {
+			"version": "4.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"imurmurhash": "^0.1.4"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/validate-npm-package-license": {
+			"version": "3.0.4",
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
+			"version": "3.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/validate-npm-package-name": {
+			"version": "5.0.1",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/walk-up-path": {
+			"version": "3.0.1",
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/which": {
+			"version": "4.0.0",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^3.1.1"
+			},
+			"bin": {
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/which/node_modules/isexe": {
+			"version": "3.1.1",
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/npm/node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
+			"version": "7.0.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
+			"version": "6.0.1",
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
+			"version": "5.1.2",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/write-file-atomic": {
+			"version": "5.0.1",
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/yallist": {
+			"version": "4.0.0",
+			"inBundle": true,
+			"license": "ISC"
+		},
 		"node_modules/nwsapi": {
 			"version": "2.2.7",
 			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
@@ -6113,6 +10384,39 @@
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object-inspect": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+			"integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/object.assign": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+			"integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+			"dependencies": {
+				"call-bind": "^1.0.5",
+				"define-properties": "^1.2.1",
+				"has-symbols": "^1.0.3",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/once": {
@@ -6151,6 +10455,39 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/p-each-series": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
+			"integrity": "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-filter": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-filter/-/p-filter-4.1.0.tgz",
+			"integrity": "sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw==",
+			"dependencies": {
+				"p-map": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-is-promise": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
+			"integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/p-limit": {
@@ -6192,6 +10529,28 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/p-map": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.2.tgz",
+			"integrity": "sha512-z4cYYMMdKHzw4O5UkWJImbZynVIo0lSGTXc7bzB1e/rrDqkgGUNysK/o4bTr+0+xKvvLoTyGqYC4Fgljy9qe1Q==",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-reduce": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-3.0.0.tgz",
+			"integrity": "sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -6228,6 +10587,17 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/parse-ms": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+			"integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/parse5": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
@@ -6238,6 +10608,19 @@
 			"funding": {
 				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+			"integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+			"dependencies": {
+				"parse5": "^6.0.1"
+			}
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
 		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
@@ -6303,12 +10686,93 @@
 				"node": ">=0.10"
 			}
 		},
+		"node_modules/pify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/pirates": {
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
 			"integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/pkg-conf": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+			"integrity": "sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==",
+			"dependencies": {
+				"find-up": "^2.0.0",
+				"load-json-file": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-conf/node_modules/find-up": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+			"integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+			"dependencies": {
+				"locate-path": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-conf/node_modules/locate-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+			"integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+			"dependencies": {
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-conf/node_modules/p-limit": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+			"dependencies": {
+				"p-try": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-conf/node_modules/p-locate": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+			"integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+			"dependencies": {
+				"p-limit": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-conf/node_modules/p-try": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+			"integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-conf/node_modules/path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/pkg-dir": {
@@ -6320,6 +10784,14 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/possible-typed-array-names": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+			"integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/prelude-ls": {
@@ -6368,6 +10840,25 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/pretty-ms": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.0.0.tgz",
+			"integrity": "sha512-E9e9HJ9R9NasGOgPaPE8VMeiPKAyWR5jcFpNnwIejslIhWqdqOrb2wShBsncMPUb+BcCd2OPYfh7p2W6oemTng==",
+			"dependencies": {
+				"parse-ms": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+		},
 		"node_modules/prompts": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -6379,6 +10870,11 @@
 			"engines": {
 				"node": ">= 6"
 			}
+		},
+		"node_modules/proto-list": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+			"integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
 		},
 		"node_modules/psl": {
 			"version": "1.9.0",
@@ -6447,6 +10943,33 @@
 				}
 			]
 		},
+		"node_modules/rc": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"dependencies": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"bin": {
+				"rc": "cli.js"
+			}
+		},
+		"node_modules/rc/node_modules/ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+		},
+		"node_modules/rc/node_modules/strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/react-is": {
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -6472,10 +10995,152 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
+		"node_modules/read-package-up": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+			"integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+			"dependencies": {
+				"find-up-simple": "^1.0.0",
+				"read-pkg": "^9.0.0",
+				"type-fest": "^4.6.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/read-package-up/node_modules/type-fest": {
+			"version": "4.18.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
+			"integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg==",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/read-pkg": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+			"integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+			"dependencies": {
+				"@types/normalize-package-data": "^2.4.3",
+				"normalize-package-data": "^6.0.0",
+				"parse-json": "^8.0.0",
+				"type-fest": "^4.6.0",
+				"unicorn-magic": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/read-pkg-up": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-11.0.0.tgz",
+			"integrity": "sha512-LOVbvF1Q0SZdjClSefZ0Nz5z8u+tIE7mV5NibzmE9VYmDe9CaBbAVtz1veOSZbofrdsilxuDAYnFenukZVp8/Q==",
+			"deprecated": "Renamed to read-package-up",
+			"dependencies": {
+				"find-up-simple": "^1.0.0",
+				"read-pkg": "^9.0.0",
+				"type-fest": "^4.6.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/read-pkg-up/node_modules/type-fest": {
+			"version": "4.18.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
+			"integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg==",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/read-pkg/node_modules/parse-json": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.1.0.tgz",
+			"integrity": "sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==",
+			"dependencies": {
+				"@babel/code-frame": "^7.22.13",
+				"index-to-position": "^0.1.2",
+				"type-fest": "^4.7.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/read-pkg/node_modules/type-fest": {
+			"version": "4.18.2",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
+			"integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg==",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
 		"node_modules/regexp-to-ast": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
 			"integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw=="
+		},
+		"node_modules/regexp.prototype.flags": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
+			"integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
+			"dependencies": {
+				"call-bind": "^1.0.6",
+				"define-properties": "^1.2.1",
+				"es-errors": "^1.3.0",
+				"set-function-name": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/registry-auth-token": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.2.tgz",
+			"integrity": "sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==",
+			"dependencies": {
+				"@pnpm/npm-conf": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=14"
+			}
 		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
@@ -6606,6 +11271,49 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"node_modules/safe-array-concat": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
+			"integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"get-intrinsic": "^1.2.4",
+				"has-symbols": "^1.0.3",
+				"isarray": "^2.0.5"
+			},
+			"engines": {
+				"node": ">=0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/safe-array-concat/node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+		},
+		"node_modules/safe-regex-test": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
+			"integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+			"dependencies": {
+				"call-bind": "^1.0.6",
+				"es-errors": "^1.3.0",
+				"is-regex": "^1.1.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -6622,12 +11330,218 @@
 				"node": ">=v12.22.7"
 			}
 		},
+		"node_modules/semantic-release": {
+			"version": "23.1.1",
+			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-23.1.1.tgz",
+			"integrity": "sha512-qqJDBhbtHsjUEMsojWKGuL5lQFCJuPtiXKEIlFKyTzDDGTAE/oyvznaP8GeOr5PvcqBJ6LQz4JCENWPLeehSpA==",
+			"dependencies": {
+				"@semantic-release/commit-analyzer": "^12.0.0",
+				"@semantic-release/error": "^4.0.0",
+				"@semantic-release/github": "^10.0.0",
+				"@semantic-release/npm": "^12.0.0",
+				"@semantic-release/release-notes-generator": "^13.0.0",
+				"aggregate-error": "^5.0.0",
+				"cosmiconfig": "^9.0.0",
+				"debug": "^4.0.0",
+				"env-ci": "^11.0.0",
+				"execa": "^9.0.0",
+				"figures": "^6.0.0",
+				"find-versions": "^6.0.0",
+				"get-stream": "^6.0.0",
+				"git-log-parser": "^1.2.0",
+				"hook-std": "^3.0.0",
+				"hosted-git-info": "^7.0.0",
+				"import-from-esm": "^1.3.1",
+				"lodash-es": "^4.17.21",
+				"marked": "^12.0.0",
+				"marked-terminal": "^7.0.0",
+				"micromatch": "^4.0.2",
+				"p-each-series": "^3.0.0",
+				"p-reduce": "^3.0.0",
+				"read-package-up": "^11.0.0",
+				"resolve-from": "^5.0.0",
+				"semver": "^7.3.2",
+				"semver-diff": "^4.0.0",
+				"signale": "^1.2.1",
+				"yargs": "^17.5.1"
+			},
+			"bin": {
+				"semantic-release": "bin/semantic-release.js"
+			},
+			"engines": {
+				"node": ">=20.8.1"
+			}
+		},
+		"node_modules/semantic-release/node_modules/@sindresorhus/merge-streams": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+			"integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/execa": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-9.1.0.tgz",
+			"integrity": "sha512-lSgHc4Elo2m6bUDhc3Hl/VxvUDJdQWI40RZ4KMY9bKRc+hgMOT7II/JjbNDhI8VnMtrCb7U/fhpJIkLORZozWw==",
+			"dependencies": {
+				"@sindresorhus/merge-streams": "^4.0.0",
+				"cross-spawn": "^7.0.3",
+				"figures": "^6.1.0",
+				"get-stream": "^9.0.0",
+				"human-signals": "^7.0.0",
+				"is-plain-obj": "^4.1.0",
+				"is-stream": "^4.0.1",
+				"npm-run-path": "^5.2.0",
+				"pretty-ms": "^9.0.0",
+				"signal-exit": "^4.1.0",
+				"strip-final-newline": "^4.0.0",
+				"yoctocolors": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/semantic-release/node_modules/execa/node_modules/get-stream": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+			"integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+			"dependencies": {
+				"@sec-ant/readable-stream": "^0.4.1",
+				"is-stream": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/human-signals": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-7.0.0.tgz",
+			"integrity": "sha512-74kytxOUSvNbjrT9KisAbaTZ/eJwD/LrbM/kh5j0IhPuJzwuA19dWvniFGwBzN9rVjg+O/e+F310PjObDXS+9Q==",
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/semantic-release/node_modules/is-stream": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+			"integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/npm-run-path": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+			"integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+			"dependencies": {
+				"path-key": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/path-key": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/semver": {
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/semantic-release/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/semantic-release/node_modules/strip-final-newline": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+			"integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/semver": {
 			"version": "6.3.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"bin": {
 				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/semver-diff": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-4.0.0.tgz",
+			"integrity": "sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==",
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semver-diff/node_modules/semver": {
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+			"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/semver-regex": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
+			"integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/set-function-length": {
@@ -6641,6 +11555,20 @@
 				"get-intrinsic": "^1.2.3",
 				"gopd": "^1.0.1",
 				"has-property-descriptors": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/set-function-name": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+			"integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"functions-have-names": "^1.2.3",
+				"has-property-descriptors": "^1.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -6673,15 +11601,131 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/side-channel": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+			"integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.4",
+				"object-inspect": "^1.13.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/signal-exit": {
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
 		},
+		"node_modules/signale": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/signale/-/signale-1.4.0.tgz",
+			"integrity": "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==",
+			"dependencies": {
+				"chalk": "^2.3.2",
+				"figures": "^2.0.0",
+				"pkg-conf": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/signale/node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/signale/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/signale/node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/signale/node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+		},
+		"node_modules/signale/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/signale/node_modules/figures": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
+			"dependencies": {
+				"escape-string-regexp": "^1.0.5"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/signale/node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/signale/node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
 			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
+		},
+		"node_modules/skin-tone": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+			"integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+			"dependencies": {
+				"unicode-emoji-modifier-base": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/slash": {
 			"version": "3.0.0",
@@ -6745,6 +11789,39 @@
 				"source-map": "^0.6.0"
 			}
 		},
+		"node_modules/spawn-error-forwarder": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
+			"integrity": "sha512-gRjMgK5uFjbCvdibeGJuy3I5OYz6VLoVdsOJdA6wV0WlfQVLFueoqMxwwYD9RODdgb6oUIvlRlsyFSiQkMKu0g=="
+		},
+		"node_modules/spdx-correct": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+			"integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+			"dependencies": {
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/spdx-exceptions": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+			"integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="
+		},
+		"node_modules/spdx-expression-parse": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+			"dependencies": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/spdx-license-ids": {
+			"version": "3.0.17",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
+			"integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg=="
+		},
 		"node_modules/split2": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -6767,6 +11844,23 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/stream-combiner2": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+			"integrity": "sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==",
+			"dependencies": {
+				"duplexer2": "~0.1.0",
+				"readable-stream": "^2.0.2"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"node_modules/string-argv": {
@@ -6800,6 +11894,52 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/string.prototype.trim": {
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
+			"integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.0",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/string.prototype.trimend": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
+			"integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/string.prototype.trimstart": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+			"integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/strip-ansi": {
@@ -6840,6 +11980,21 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/super-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.0.0.tgz",
+			"integrity": "sha512-CY8u7DtbvucKuquCmOFEKhr9Besln7n9uN8eFbwcoGYWXOMW07u2o8njWaiXt11ylS3qoGF55pILjRmPlbodyg==",
+			"dependencies": {
+				"function-timeout": "^1.0.1",
+				"time-span": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6849,6 +12004,18 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/supports-hyperlinks": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
+			"integrity": "sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==",
+			"dependencies": {
+				"has-flag": "^4.0.0",
+				"supports-color": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=14.18"
 			}
 		},
 		"node_modules/supports-preserve-symlinks-flag": {
@@ -6866,6 +12033,53 @@
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+		},
+		"node_modules/temp-dir": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+			"integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+			"engines": {
+				"node": ">=14.16"
+			}
+		},
+		"node_modules/tempy": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+			"integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+			"dependencies": {
+				"is-stream": "^3.0.0",
+				"temp-dir": "^3.0.0",
+				"type-fest": "^2.12.2",
+				"unique-string": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/tempy/node_modules/is-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+			"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/tempy/node_modules/type-fest": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+			"engines": {
+				"node": ">=12.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/test-exclude": {
 			"version": "6.0.0",
@@ -6896,10 +12110,52 @@
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
 		},
+		"node_modules/thenify": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+			"dependencies": {
+				"any-promise": "^1.0.0"
+			}
+		},
+		"node_modules/thenify-all": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+			"integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+			"dependencies": {
+				"thenify": ">= 3.1.0 < 4"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
 		"node_modules/through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+		},
+		"node_modules/through2": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+			"dependencies": {
+				"readable-stream": "~2.3.6",
+				"xtend": "~4.0.1"
+			}
+		},
+		"node_modules/time-span": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+			"integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+			"dependencies": {
+				"convert-hrtime": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/tmpl": {
 			"version": "1.0.5",
@@ -6950,6 +12206,22 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/traverse": {
+			"version": "0.6.9",
+			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.9.tgz",
+			"integrity": "sha512-7bBrcF+/LQzSgFmT0X5YclVqQxtv7TDJ1f8Wj7ibBu/U6BMLeOpUxuZjV7rMc44UtKxlnMFigdhFAIszSX1DMg==",
+			"dependencies": {
+				"gopd": "^1.0.1",
+				"typedarray.prototype.slice": "^1.0.3",
+				"which-typed-array": "^1.1.15"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/ts-api-utils": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
@@ -6991,6 +12263,94 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/typed-array-buffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
+			"integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"is-typed-array": "^1.1.13"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/typed-array-byte-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
+			"integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-proto": "^1.0.3",
+				"is-typed-array": "^1.1.13"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/typed-array-byte-offset": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
+			"integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
+			"dependencies": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-proto": "^1.0.3",
+				"is-typed-array": "^1.1.13"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/typed-array-length": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
+			"integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-proto": "^1.0.3",
+				"is-typed-array": "^1.1.13",
+				"possible-typed-array-names": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/typedarray.prototype.slice": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/typedarray.prototype.slice/-/typedarray.prototype.slice-1.0.3.tgz",
+			"integrity": "sha512-8WbVAQAUlENo1q3c3zZYuy5k9VzBQvp8AX9WOtbvyWlLM1v5JaSRmjubLjzHF4JFtptjH/5c/i95yaElvcjC0A==",
+			"dependencies": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.0",
+				"es-errors": "^1.3.0",
+				"typed-array-buffer": "^1.0.2",
+				"typed-array-byte-offset": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/typescript": {
 			"version": "5.4.5",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
@@ -7003,10 +12363,44 @@
 				"node": ">=14.17"
 			}
 		},
+		"node_modules/uglify-js": {
+			"version": "3.17.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+			"integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+			"optional": true,
+			"bin": {
+				"uglifyjs": "bin/uglifyjs"
+			},
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/unbox-primitive": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+			"integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"has-bigints": "^1.0.2",
+				"has-symbols": "^1.0.3",
+				"which-boxed-primitive": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/undici-types": {
 			"version": "5.26.5",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
 			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+		},
+		"node_modules/unicode-emoji-modifier-base": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+			"integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+			"engines": {
+				"node": ">=4"
+			}
 		},
 		"node_modules/unicorn-magic": {
 			"version": "0.1.0",
@@ -7018,6 +12412,25 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/unique-string": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+			"integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+			"dependencies": {
+				"crypto-random-string": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/universal-user-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
+			"integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q=="
 		},
 		"node_modules/universalify": {
 			"version": "0.2.0",
@@ -7064,6 +12477,14 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"node_modules/url-join": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
+			"integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			}
+		},
 		"node_modules/url-parse": {
 			"version": "1.5.10",
 			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -7072,6 +12493,11 @@
 				"querystringify": "^2.1.1",
 				"requires-port": "^1.0.0"
 			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
 		},
 		"node_modules/v8-to-istanbul": {
 			"version": "9.2.0",
@@ -7084,6 +12510,15 @@
 			},
 			"engines": {
 				"node": ">=10.12.0"
+			}
+		},
+		"node_modules/validate-npm-package-license": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"dependencies": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
 			}
 		},
 		"node_modules/w3c-xmlserializer": {
@@ -7158,6 +12593,44 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/which-boxed-primitive": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+			"dependencies": {
+				"is-bigint": "^1.0.1",
+				"is-boolean-object": "^1.1.0",
+				"is-number-object": "^1.0.4",
+				"is-string": "^1.0.5",
+				"is-symbol": "^1.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/which-typed-array": {
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
+			"integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+			"dependencies": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
+		},
 		"node_modules/wrap-ansi": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -7224,6 +12697,14 @@
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
 		},
+		"node_modules/xtend": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+			"engines": {
+				"node": ">=0.4"
+			}
+		},
 		"node_modules/y18n": {
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -7276,6 +12757,17 @@
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/yoctocolors": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.0.2.tgz",
+			"integrity": "sha512-Ct97huExsu7cWeEjmrXlofevF8CvzUglJ4iGUet5B8xn1oumtAZBpHU4GzYuoE6PVqcZ5hghtBrSlhwHuR1Jmw==",
+			"engines": {
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -7721,6 +13213,12 @@
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
 			"integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
+		},
+		"@colors/colors": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+			"optional": true
 		},
 		"@commitlint/cli": {
 			"version": "19.3.0",
@@ -8619,6 +14117,133 @@
 				"fastq": "^1.6.0"
 			}
 		},
+		"@octokit/auth-token": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.1.tgz",
+			"integrity": "sha512-rh3G3wDO8J9wSjfI436JUKzHIxq8NaiL0tVeB2aXmG6p/9859aUOAjA9pmSPNGGZxfwmaJ9ozOJImuNVJdpvbA=="
+		},
+		"@octokit/core": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.2.tgz",
+			"integrity": "sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==",
+			"requires": {
+				"@octokit/auth-token": "^5.0.0",
+				"@octokit/graphql": "^8.0.0",
+				"@octokit/request": "^9.0.0",
+				"@octokit/request-error": "^6.0.1",
+				"@octokit/types": "^13.0.0",
+				"before-after-hook": "^3.0.2",
+				"universal-user-agent": "^7.0.0"
+			}
+		},
+		"@octokit/endpoint": {
+			"version": "10.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.1.tgz",
+			"integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
+			"requires": {
+				"@octokit/types": "^13.0.0",
+				"universal-user-agent": "^7.0.2"
+			}
+		},
+		"@octokit/graphql": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.1.1.tgz",
+			"integrity": "sha512-ukiRmuHTi6ebQx/HFRCXKbDlOh/7xEV6QUXaE7MJEKGNAncGI/STSbOkl12qVXZrfZdpXctx5O9X1AIaebiDBg==",
+			"requires": {
+				"@octokit/request": "^9.0.0",
+				"@octokit/types": "^13.0.0",
+				"universal-user-agent": "^7.0.0"
+			}
+		},
+		"@octokit/openapi-types": {
+			"version": "22.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
+			"integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg=="
+		},
+		"@octokit/plugin-paginate-rest": {
+			"version": "11.3.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.0.tgz",
+			"integrity": "sha512-n4znWfRinnUQF6TPyxs7EctSAA3yVSP4qlJP2YgI3g9d4Ae2n5F3XDOjbUluKRxPU3rfsgpOboI4O4VtPc6Ilg==",
+			"requires": {
+				"@octokit/types": "^13.5.0"
+			}
+		},
+		"@octokit/plugin-retry": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-7.1.1.tgz",
+			"integrity": "sha512-G9Ue+x2odcb8E1XIPhaFBnTTIrrUDfXN05iFXiqhR+SeeeDMMILcAnysOsxUpEWcQp2e5Ft397FCXTcPkiPkLw==",
+			"requires": {
+				"@octokit/request-error": "^6.0.0",
+				"@octokit/types": "^13.0.0",
+				"bottleneck": "^2.15.3"
+			}
+		},
+		"@octokit/plugin-throttling": {
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-9.3.0.tgz",
+			"integrity": "sha512-B5YTToSRTzNSeEyssnrT7WwGhpIdbpV9NKIs3KyTWHX6PhpYn7gqF/+lL3BvsASBM3Sg5BAUYk7KZx5p/Ec77w==",
+			"requires": {
+				"@octokit/types": "^13.0.0",
+				"bottleneck": "^2.15.3"
+			}
+		},
+		"@octokit/request": {
+			"version": "9.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.1.tgz",
+			"integrity": "sha512-pyAguc0p+f+GbQho0uNetNQMmLG1e80WjkIaqqgUkihqUp0boRU6nKItXO4VWnr+nbZiLGEyy4TeKRwqaLvYgw==",
+			"requires": {
+				"@octokit/endpoint": "^10.0.0",
+				"@octokit/request-error": "^6.0.1",
+				"@octokit/types": "^13.1.0",
+				"universal-user-agent": "^7.0.2"
+			}
+		},
+		"@octokit/request-error": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.1.tgz",
+			"integrity": "sha512-1mw1gqT3fR/WFvnoVpY/zUM2o/XkMs/2AszUUG9I69xn0JFLv6PGkPhNk5lbfvROs79wiS0bqiJNxfCZcRJJdg==",
+			"requires": {
+				"@octokit/types": "^13.0.0"
+			}
+		},
+		"@octokit/types": {
+			"version": "13.5.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.5.0.tgz",
+			"integrity": "sha512-HdqWTf5Z3qwDVlzCrP8UJquMwunpDiMPt5er+QjGzL4hqr/vBVY/MauQgS1xWxCDT1oMx1EULyqxncdCY/NVSQ==",
+			"requires": {
+				"@octokit/openapi-types": "^22.2.0"
+			}
+		},
+		"@pnpm/config.env-replace": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+			"integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w=="
+		},
+		"@pnpm/network.ca-file": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+			"integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+			"requires": {
+				"graceful-fs": "4.2.10"
+			},
+			"dependencies": {
+				"graceful-fs": {
+					"version": "4.2.10",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+					"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+				}
+			}
+		},
+		"@pnpm/npm-conf": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.2.2.tgz",
+			"integrity": "sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==",
+			"requires": {
+				"@pnpm/config.env-replace": "^1.1.0",
+				"@pnpm/network.ca-file": "^1.0.1",
+				"config-chain": "^1.1.11"
+			}
+		},
 		"@prettier/plugin-pug": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/@prettier/plugin-pug/-/plugin-pug-3.0.0.tgz",
@@ -8635,10 +14260,235 @@
 				"@xml-tools/parser": "^1.0.11"
 			}
 		},
+		"@sec-ant/readable-stream": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+			"integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="
+		},
+		"@semantic-release/commit-analyzer": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-12.0.0.tgz",
+			"integrity": "sha512-qG+md5gdes+xa8zP7lIo1fWE17zRdO8yMCaxh9lyL65TQleoSv8WHHOqRURfghTytUh+NpkSyBprQ5hrkxOKVQ==",
+			"requires": {
+				"conventional-changelog-angular": "^7.0.0",
+				"conventional-commits-filter": "^4.0.0",
+				"conventional-commits-parser": "^5.0.0",
+				"debug": "^4.0.0",
+				"import-from-esm": "^1.0.3",
+				"lodash-es": "^4.17.21",
+				"micromatch": "^4.0.2"
+			}
+		},
+		"@semantic-release/error": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+			"integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ=="
+		},
+		"@semantic-release/github": {
+			"version": "10.0.4",
+			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-10.0.4.tgz",
+			"integrity": "sha512-eHCfW3jlzax5OKd5nTovlvoCdg+b9YBa31M2JGT1KmzmJR3TIalu2ahVU+V/xATVeOx+S8fbCiPnBBgMlzH5Vw==",
+			"requires": {
+				"@octokit/core": "^6.0.0",
+				"@octokit/plugin-paginate-rest": "^11.0.0",
+				"@octokit/plugin-retry": "^7.0.0",
+				"@octokit/plugin-throttling": "^9.0.0",
+				"@semantic-release/error": "^4.0.0",
+				"aggregate-error": "^5.0.0",
+				"debug": "^4.3.4",
+				"dir-glob": "^3.0.1",
+				"globby": "^14.0.0",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.0",
+				"issue-parser": "^7.0.0",
+				"lodash-es": "^4.17.21",
+				"mime": "^4.0.0",
+				"p-filter": "^4.0.0",
+				"url-join": "^5.0.0"
+			},
+			"dependencies": {
+				"agent-base": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+					"integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+					"requires": {
+						"debug": "^4.3.4"
+					}
+				},
+				"globby": {
+					"version": "14.0.1",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-14.0.1.tgz",
+					"integrity": "sha512-jOMLD2Z7MAhyG8aJpNOpmziMOP4rPLcc95oQPKXBazW82z+CEgPFBQvEpRUa1KeIMUJo4Wsm+q6uzO/Q/4BksQ==",
+					"requires": {
+						"@sindresorhus/merge-streams": "^2.1.0",
+						"fast-glob": "^3.3.2",
+						"ignore": "^5.2.4",
+						"path-type": "^5.0.0",
+						"slash": "^5.1.0",
+						"unicorn-magic": "^0.1.0"
+					}
+				},
+				"http-proxy-agent": {
+					"version": "7.0.2",
+					"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+					"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+					"requires": {
+						"agent-base": "^7.1.0",
+						"debug": "^4.3.4"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "7.0.4",
+					"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+					"integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+					"requires": {
+						"agent-base": "^7.0.2",
+						"debug": "4"
+					}
+				},
+				"path-type": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+					"integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg=="
+				},
+				"slash": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+					"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="
+				}
+			}
+		},
+		"@semantic-release/npm": {
+			"version": "12.0.1",
+			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-12.0.1.tgz",
+			"integrity": "sha512-/6nntGSUGK2aTOI0rHPwY3ZjgY9FkXmEHbW9Kr+62NVOsyqpKKeP0lrCH+tphv+EsNdJNmqqwijTEnVWUMQ2Nw==",
+			"requires": {
+				"@semantic-release/error": "^4.0.0",
+				"aggregate-error": "^5.0.0",
+				"execa": "^9.0.0",
+				"fs-extra": "^11.0.0",
+				"lodash-es": "^4.17.21",
+				"nerf-dart": "^1.0.0",
+				"normalize-url": "^8.0.0",
+				"npm": "^10.5.0",
+				"rc": "^1.2.8",
+				"read-pkg": "^9.0.0",
+				"registry-auth-token": "^5.0.0",
+				"semver": "^7.1.2",
+				"tempy": "^3.0.0"
+			},
+			"dependencies": {
+				"@sindresorhus/merge-streams": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+					"integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="
+				},
+				"execa": {
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-9.1.0.tgz",
+					"integrity": "sha512-lSgHc4Elo2m6bUDhc3Hl/VxvUDJdQWI40RZ4KMY9bKRc+hgMOT7II/JjbNDhI8VnMtrCb7U/fhpJIkLORZozWw==",
+					"requires": {
+						"@sindresorhus/merge-streams": "^4.0.0",
+						"cross-spawn": "^7.0.3",
+						"figures": "^6.1.0",
+						"get-stream": "^9.0.0",
+						"human-signals": "^7.0.0",
+						"is-plain-obj": "^4.1.0",
+						"is-stream": "^4.0.1",
+						"npm-run-path": "^5.2.0",
+						"pretty-ms": "^9.0.0",
+						"signal-exit": "^4.1.0",
+						"strip-final-newline": "^4.0.0",
+						"yoctocolors": "^2.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "9.0.1",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+					"integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+					"requires": {
+						"@sec-ant/readable-stream": "^0.4.1",
+						"is-stream": "^4.0.1"
+					}
+				},
+				"human-signals": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-7.0.0.tgz",
+					"integrity": "sha512-74kytxOUSvNbjrT9KisAbaTZ/eJwD/LrbM/kh5j0IhPuJzwuA19dWvniFGwBzN9rVjg+O/e+F310PjObDXS+9Q=="
+				},
+				"is-stream": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+					"integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="
+				},
+				"npm-run-path": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+					"integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+					"requires": {
+						"path-key": "^4.0.0"
+					}
+				},
+				"path-key": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+					"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="
+				},
+				"semver": {
+					"version": "7.6.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+					"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w=="
+				},
+				"signal-exit": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+					"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
+				},
+				"strip-final-newline": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+					"integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="
+				}
+			}
+		},
+		"@semantic-release/release-notes-generator": {
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-13.0.0.tgz",
+			"integrity": "sha512-LEeZWb340keMYuREMyxrODPXJJ0JOL8D/mCl74B4LdzbxhtXV2LrPN2QBEcGJrlQhoqLO0RhxQb6masHytKw+A==",
+			"requires": {
+				"conventional-changelog-angular": "^7.0.0",
+				"conventional-changelog-writer": "^7.0.0",
+				"conventional-commits-filter": "^4.0.0",
+				"conventional-commits-parser": "^5.0.0",
+				"debug": "^4.0.0",
+				"get-stream": "^7.0.0",
+				"import-from-esm": "^1.0.3",
+				"into-stream": "^7.0.0",
+				"lodash-es": "^4.17.21",
+				"read-pkg-up": "^11.0.0"
+			},
+			"dependencies": {
+				"get-stream": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.1.tgz",
+					"integrity": "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ=="
+				}
+			}
+		},
 		"@sinclair/typebox": {
 			"version": "0.27.8",
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
 			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
+		},
+		"@sindresorhus/is": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="
+		},
+		"@sindresorhus/merge-streams": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+			"integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg=="
 		},
 		"@sinonjs/commons": {
 			"version": "3.0.0",
@@ -8893,6 +14743,11 @@
 				"undici-types": "~5.26.4"
 			}
 		},
+		"@types/normalize-package-data": {
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="
+		},
 		"@types/stack-utils": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
@@ -9078,6 +14933,15 @@
 				"debug": "4"
 			}
 		},
+		"aggregate-error": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
+			"integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
+			"requires": {
+				"clean-stack": "^5.2.0",
+				"indent-string": "^5.0.0"
+			}
+		},
 		"ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -9110,6 +14974,11 @@
 				"color-convert": "^2.0.1"
 			}
 		},
+		"any-promise": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
+		},
 		"anymatch": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -9127,6 +14996,20 @@
 				"sprintf-js": "~1.0.2"
 			}
 		},
+		"argv-formatter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
+			"integrity": "sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw=="
+		},
+		"array-buffer-byte-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
+			"integrity": "sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==",
+			"requires": {
+				"call-bind": "^1.0.5",
+				"is-array-buffer": "^3.0.4"
+			}
+		},
 		"array-ify": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
@@ -9137,10 +15020,33 @@
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
 		},
+		"arraybuffer.prototype.slice": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
+			"integrity": "sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==",
+			"requires": {
+				"array-buffer-byte-length": "^1.0.1",
+				"call-bind": "^1.0.5",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.22.3",
+				"es-errors": "^1.2.1",
+				"get-intrinsic": "^1.2.3",
+				"is-array-buffer": "^3.0.4",
+				"is-shared-array-buffer": "^1.0.2"
+			}
+		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+		},
+		"available-typed-arrays": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+			"requires": {
+				"possible-typed-array-names": "^1.0.0"
+			}
 		},
 		"babel-jest": {
 			"version": "29.7.0",
@@ -9211,6 +15117,16 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+		},
+		"before-after-hook": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+			"integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A=="
+		},
+		"bottleneck": {
+			"version": "2.19.5",
+			"resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+			"integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -9320,12 +15236,85 @@
 			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
 			"integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
 		},
+		"clean-stack": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.2.0.tgz",
+			"integrity": "sha512-TyUIUJgdFnCISzG5zu3291TAsE77ddchd0bepon1VVQrKLGKFED4iXFEDQ24mIPdPBbyE16PK3F8MYE1CmcBEQ==",
+			"requires": {
+				"escape-string-regexp": "5.0.0"
+			},
+			"dependencies": {
+				"escape-string-regexp": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+					"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
+				}
+			}
+		},
 		"cli-cursor": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
 			"integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
 			"requires": {
 				"restore-cursor": "^4.0.0"
+			}
+		},
+		"cli-highlight": {
+			"version": "2.1.11",
+			"resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+			"integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+			"requires": {
+				"chalk": "^4.0.0",
+				"highlight.js": "^10.7.1",
+				"mz": "^2.4.0",
+				"parse5": "^5.1.1",
+				"parse5-htmlparser2-tree-adapter": "^6.0.0",
+				"yargs": "^16.0.0"
+			},
+			"dependencies": {
+				"cliui": {
+					"version": "7.0.4",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+					"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^7.0.0"
+					}
+				},
+				"parse5": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+					"integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
+				},
+				"yargs": {
+					"version": "16.2.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+					"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+					"requires": {
+						"cliui": "^7.0.2",
+						"escalade": "^3.1.1",
+						"get-caller-file": "^2.0.5",
+						"require-directory": "^2.1.1",
+						"string-width": "^4.2.0",
+						"y18n": "^5.0.5",
+						"yargs-parser": "^20.2.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "20.2.9",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+					"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+				}
+			}
+		},
+		"cli-table3": {
+			"version": "0.6.5",
+			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+			"integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+			"requires": {
+				"@colors/colors": "1.5.0",
+				"string-width": "^4.2.0"
 			}
 		},
 		"cli-truncate": {
@@ -9432,6 +15421,22 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
 		},
+		"config-chain": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+			"integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+			"requires": {
+				"ini": "^1.3.4",
+				"proto-list": "~1.2.1"
+			},
+			"dependencies": {
+				"ini": {
+					"version": "1.3.8",
+					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+					"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+				}
+			}
+		},
 		"conventional-changelog-angular": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
@@ -9448,6 +15453,31 @@
 				"compare-func": "^2.0.0"
 			}
 		},
+		"conventional-changelog-writer": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-7.0.1.tgz",
+			"integrity": "sha512-Uo+R9neH3r/foIvQ0MKcsXkX642hdm9odUp7TqgFS7BsalTcjzRlIfWZrZR1gbxOozKucaKt5KAbjW8J8xRSmA==",
+			"requires": {
+				"conventional-commits-filter": "^4.0.0",
+				"handlebars": "^4.7.7",
+				"json-stringify-safe": "^5.0.1",
+				"meow": "^12.0.1",
+				"semver": "^7.5.2",
+				"split2": "^4.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.6.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+					"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w=="
+				}
+			}
+		},
+		"conventional-commits-filter": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-4.0.0.tgz",
+			"integrity": "sha512-rnpnibcSOdFcdclpFwWa+pPlZJhXE7l+XK04zxhbWrhgpR96h33QLz8hITTXbcYICxVr3HZFtbtUAQ+4LdBo9A=="
+		},
 		"conventional-commits-parser": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz",
@@ -9459,10 +15489,20 @@
 				"split2": "^4.0.0"
 			}
 		},
+		"convert-hrtime": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+			"integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg=="
+		},
 		"convert-source-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
+		},
+		"core-util-is": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
 		},
 		"cosmiconfig": {
 			"version": "9.0.0",
@@ -9522,6 +15562,21 @@
 				"which": "^2.0.1"
 			}
 		},
+		"crypto-random-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+			"integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+			"requires": {
+				"type-fest": "^1.0.1"
+			},
+			"dependencies": {
+				"type-fest": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+					"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+				}
+			}
+		},
 		"cssom": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
@@ -9557,6 +15612,36 @@
 				"whatwg-url": "^11.0.0"
 			}
 		},
+		"data-view-buffer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
+			"integrity": "sha512-0lht7OugA5x3iJLOWFhWK/5ehONdprk0ISXqVFn/NFrDu+cuc8iADFrGQz5BnRK7LLU3JmkbXSxaqX+/mXYtUA==",
+			"requires": {
+				"call-bind": "^1.0.6",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.1"
+			}
+		},
+		"data-view-byte-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
+			"integrity": "sha512-4J7wRJD3ABAzr8wP+OcIcqq2dlUKp4DVflx++hs5h5ZKydWMI6/D/fAot+yh6g2tHh8fLFTvNOaVN357NvSrOQ==",
+			"requires": {
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.1"
+			}
+		},
+		"data-view-byte-offset": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
+			"integrity": "sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==",
+			"requires": {
+				"call-bind": "^1.0.6",
+				"es-errors": "^1.3.0",
+				"is-data-view": "^1.0.1"
+			}
+		},
 		"debug": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -9576,6 +15661,11 @@
 			"integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
 			"requires": {}
 		},
+		"deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+		},
 		"deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -9594,6 +15684,16 @@
 				"es-define-property": "^1.0.0",
 				"es-errors": "^1.3.0",
 				"gopd": "^1.0.1"
+			}
+		},
+		"define-properties": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+			"requires": {
+				"define-data-property": "^1.0.1",
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
 			}
 		},
 		"delayed-stream": {
@@ -9643,6 +15743,14 @@
 				"is-obj": "^2.0.0"
 			}
 		},
+		"duplexer2": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+			"integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+			"requires": {
+				"readable-stream": "^2.0.2"
+			}
+		},
 		"electron-to-chromium": {
 			"version": "1.4.603",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.603.tgz",
@@ -9658,10 +15766,93 @@
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
 		},
+		"emojilib": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+			"integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="
+		},
 		"entities": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
 			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+		},
+		"env-ci": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/env-ci/-/env-ci-11.0.0.tgz",
+			"integrity": "sha512-apikxMgkipkgTvMdRT9MNqWx5VLOci79F4VBd7Op/7OPjjoanjdAvn6fglMCCEf/1bAh8eOiuEVCUs4V3qP3nQ==",
+			"requires": {
+				"execa": "^8.0.0",
+				"java-properties": "^1.0.2"
+			},
+			"dependencies": {
+				"execa": {
+					"version": "8.0.1",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+					"integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+					"requires": {
+						"cross-spawn": "^7.0.3",
+						"get-stream": "^8.0.1",
+						"human-signals": "^5.0.0",
+						"is-stream": "^3.0.0",
+						"merge-stream": "^2.0.0",
+						"npm-run-path": "^5.1.0",
+						"onetime": "^6.0.0",
+						"signal-exit": "^4.1.0",
+						"strip-final-newline": "^3.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "8.0.1",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+					"integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA=="
+				},
+				"human-signals": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+					"integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ=="
+				},
+				"is-stream": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+					"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="
+				},
+				"mimic-fn": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+					"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="
+				},
+				"npm-run-path": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+					"integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+					"requires": {
+						"path-key": "^4.0.0"
+					}
+				},
+				"onetime": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+					"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+					"requires": {
+						"mimic-fn": "^4.0.0"
+					}
+				},
+				"path-key": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+					"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="
+				},
+				"signal-exit": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+					"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
+				},
+				"strip-final-newline": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+					"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="
+				}
+			}
 		},
 		"env-paths": {
 			"version": "2.2.1",
@@ -9676,6 +15867,59 @@
 				"is-arrayish": "^0.2.1"
 			}
 		},
+		"es-abstract": {
+			"version": "1.23.3",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.3.tgz",
+			"integrity": "sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==",
+			"requires": {
+				"array-buffer-byte-length": "^1.0.1",
+				"arraybuffer.prototype.slice": "^1.0.3",
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.7",
+				"data-view-buffer": "^1.0.1",
+				"data-view-byte-length": "^1.0.1",
+				"data-view-byte-offset": "^1.0.0",
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.0.0",
+				"es-set-tostringtag": "^2.0.3",
+				"es-to-primitive": "^1.2.1",
+				"function.prototype.name": "^1.1.6",
+				"get-intrinsic": "^1.2.4",
+				"get-symbol-description": "^1.0.2",
+				"globalthis": "^1.0.3",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2",
+				"has-proto": "^1.0.3",
+				"has-symbols": "^1.0.3",
+				"hasown": "^2.0.2",
+				"internal-slot": "^1.0.7",
+				"is-array-buffer": "^3.0.4",
+				"is-callable": "^1.2.7",
+				"is-data-view": "^1.0.1",
+				"is-negative-zero": "^2.0.3",
+				"is-regex": "^1.1.4",
+				"is-shared-array-buffer": "^1.0.3",
+				"is-string": "^1.0.7",
+				"is-typed-array": "^1.1.13",
+				"is-weakref": "^1.0.2",
+				"object-inspect": "^1.13.1",
+				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.5",
+				"regexp.prototype.flags": "^1.5.2",
+				"safe-array-concat": "^1.1.2",
+				"safe-regex-test": "^1.0.3",
+				"string.prototype.trim": "^1.2.9",
+				"string.prototype.trimend": "^1.0.8",
+				"string.prototype.trimstart": "^1.0.8",
+				"typed-array-buffer": "^1.0.2",
+				"typed-array-byte-length": "^1.0.1",
+				"typed-array-byte-offset": "^1.0.2",
+				"typed-array-length": "^1.0.6",
+				"unbox-primitive": "^1.0.2",
+				"which-typed-array": "^1.1.15"
+			}
+		},
 		"es-define-property": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
@@ -9688,6 +15932,34 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
 			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+		},
+		"es-object-atoms": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+			"integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+			"requires": {
+				"es-errors": "^1.3.0"
+			}
+		},
+		"es-set-tostringtag": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
+			"integrity": "sha512-3T8uNMC3OQTHkFUsFq8r/BwAXLHvU/9O9mE0fBc/MY5iq/8H7ncvO947LmYA6ldWw9Uh8Yhf25zu6n7nML5QWQ==",
+			"requires": {
+				"get-intrinsic": "^1.2.4",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.1"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+			"requires": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
+			}
 		},
 		"escalade": {
 			"version": "3.1.1",
@@ -9959,6 +16231,14 @@
 				"bser": "2.1.1"
 			}
 		},
+		"figures": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+			"integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+			"requires": {
+				"is-unicode-supported": "^2.0.0"
+			}
+		},
 		"file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -9984,6 +16264,20 @@
 				"path-exists": "^4.0.0"
 			}
 		},
+		"find-up-simple": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.0.tgz",
+			"integrity": "sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw=="
+		},
+		"find-versions": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/find-versions/-/find-versions-6.0.0.tgz",
+			"integrity": "sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==",
+			"requires": {
+				"semver-regex": "^4.0.5",
+				"super-regex": "^1.0.0"
+			}
+		},
 		"flat-cache": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
@@ -9999,6 +16293,14 @@
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
 			"integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
 		},
+		"for-each": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+			"requires": {
+				"is-callable": "^1.1.3"
+			}
+		},
 		"form-data": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -10007,6 +16309,32 @@
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"mime-types": "^2.1.12"
+			}
+		},
+		"from2": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+			"integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
+			"requires": {
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0"
+			}
+		},
+		"fs-extra": {
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+			"integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+			"requires": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"dependencies": {
+				"universalify": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+					"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
+				}
 			}
 		},
 		"fs.realpath": {
@@ -10024,6 +16352,27 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+		},
+		"function-timeout": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
+			"integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA=="
+		},
+		"function.prototype.name": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
+			"integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.2.0",
+				"es-abstract": "^1.22.1",
+				"functions-have-names": "^1.2.3"
+			}
+		},
+		"functions-have-names": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
 		},
 		"gensync": {
 			"version": "1.0.0-beta.2",
@@ -10061,6 +16410,39 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
 			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
+		},
+		"get-symbol-description": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
+			"integrity": "sha512-g0QYk1dZBxGwk+Ngc+ltRH2IBp2f7zBkBMBJZCDerh6EhlhSR6+9irMCuT/09zD6qkarHUSn529sK/yL4S27mg==",
+			"requires": {
+				"call-bind": "^1.0.5",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.4"
+			}
+		},
+		"git-log-parser": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.0.tgz",
+			"integrity": "sha512-rnCVNfkTL8tdNryFuaY0fYiBWEBcgF748O6ZI61rslBvr2o7U65c2/6npCRqH40vuAhtgtDiqLTJjBVdrejCzA==",
+			"requires": {
+				"argv-formatter": "~1.0.0",
+				"spawn-error-forwarder": "~1.0.0",
+				"split2": "~1.0.0",
+				"stream-combiner2": "~1.1.1",
+				"through2": "~2.0.0",
+				"traverse": "~0.6.6"
+			},
+			"dependencies": {
+				"split2": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
+					"integrity": "sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg==",
+					"requires": {
+						"through2": "~2.0.0"
+					}
+				}
+			}
 		},
 		"git-raw-commits": {
 			"version": "4.0.0",
@@ -10106,6 +16488,15 @@
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
 			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
 		},
+		"globalthis": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+			"integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+			"requires": {
+				"define-properties": "^1.2.1",
+				"gopd": "^1.0.1"
+			}
+		},
 		"globby": {
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -10137,6 +16528,18 @@
 			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
 		},
+		"handlebars": {
+			"version": "4.7.8",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+			"requires": {
+				"minimist": "^1.2.5",
+				"neo-async": "^2.6.2",
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4",
+				"wordwrap": "^1.0.0"
+			}
+		},
 		"has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -10144,6 +16547,11 @@
 			"requires": {
 				"function-bind": "^1.1.1"
 			}
+		},
+		"has-bigints": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ=="
 		},
 		"has-flag": {
 			"version": "4.0.0",
@@ -10182,6 +16590,31 @@
 			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
 			"requires": {
 				"function-bind": "^1.1.2"
+			}
+		},
+		"highlight.js": {
+			"version": "10.7.3",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
+		},
+		"hook-std": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/hook-std/-/hook-std-3.0.0.tgz",
+			"integrity": "sha512-jHRQzjSDzMtFy34AGj1DN+vq54WVuhSvKgrHf0OMiFQTwDD4L/qqofVEWjLOBMTn5+lCD3fPg32W9yOfnEJTTw=="
+		},
+		"hosted-git-info": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+			"integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+			"requires": {
+				"lru-cache": "^10.0.1"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "10.2.2",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+					"integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ=="
+				}
 			}
 		},
 		"html-encoding-sniffer": {
@@ -10256,6 +16689,15 @@
 				}
 			}
 		},
+		"import-from-esm": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-1.3.4.tgz",
+			"integrity": "sha512-7EyUlPFC0HOlBDpUFGfYstsU7XHxZJKAAMzCT8wZ0hMW7b+hG51LIKTDcsgtz8Pu6YC0HqRVbX+rVUtsGMUKvg==",
+			"requires": {
+				"debug": "^4.3.4",
+				"import-meta-resolve": "^4.0.0"
+			}
+		},
 		"import-local": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
@@ -10274,6 +16716,16 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="
+		},
+		"indent-string": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
+		},
+		"index-to-position": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-0.1.2.tgz",
+			"integrity": "sha512-MWDKS3AS1bGCHLBA2VLImJz42f7bJh8wQsTGCzI3j519/CASStoDONUBVz2I/VID0MpiX3SGSnbOD2xUalbE5g=="
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -10294,10 +16746,60 @@
 			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
 			"integrity": "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g=="
 		},
+		"internal-slot": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
+			"integrity": "sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==",
+			"requires": {
+				"es-errors": "^1.3.0",
+				"hasown": "^2.0.0",
+				"side-channel": "^1.0.4"
+			}
+		},
+		"into-stream": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-7.0.0.tgz",
+			"integrity": "sha512-2dYz766i9HprMBasCMvHMuazJ7u4WzhJwo5kb3iPSiW/iRYV6uPari3zHoqZlnuaR7V1bEiNMxikhp37rdBXbw==",
+			"requires": {
+				"from2": "^2.3.0",
+				"p-is-promise": "^3.0.0"
+			}
+		},
+		"is-array-buffer": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
+			"integrity": "sha512-wcjaerHw0ydZwfhiKbXJWLDY8A7yV7KhjQOpb83hGgGfId/aQa4TOvwyzn2PuswW2gPCYEL/nEAiSVpdOj1lXw==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"get-intrinsic": "^1.2.1"
+			}
+		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
+		},
+		"is-bigint": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+			"requires": {
+				"has-bigints": "^1.0.1"
+			}
+		},
+		"is-boolean-object": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+			"integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"has-tostringtag": "^1.0.0"
+			}
+		},
+		"is-callable": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
 		},
 		"is-core-module": {
 			"version": "2.12.1",
@@ -10305,6 +16807,22 @@
 			"integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
 			"requires": {
 				"has": "^1.0.3"
+			}
+		},
+		"is-data-view": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.1.tgz",
+			"integrity": "sha512-AHkaJrsUVW6wq6JS8y3JnM/GJF/9cf+k20+iDzlSaJrinEo5+7vRiteOSwBhHRiAyQATN1AmY4hwzxJKPmYf+w==",
+			"requires": {
+				"is-typed-array": "^1.1.13"
+			}
+		},
+		"is-date-object": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+			"integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+			"requires": {
+				"has-tostringtag": "^1.0.0"
 			}
 		},
 		"is-expression": {
@@ -10346,10 +16864,23 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
+		"is-negative-zero": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+			"integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw=="
+		},
 		"is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+		},
+		"is-number-object": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+			"integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+			"requires": {
+				"has-tostringtag": "^1.0.0"
+			}
 		},
 		"is-obj": {
 			"version": "2.0.0",
@@ -10360,6 +16891,11 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ=="
+		},
+		"is-plain-obj": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+			"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
 		},
 		"is-potential-custom-element-name": {
 			"version": "1.0.1",
@@ -10375,10 +16911,34 @@
 				"has-tostringtag": "^1.0.0"
 			}
 		},
+		"is-shared-array-buffer": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
+			"integrity": "sha512-nA2hv5XIhLR3uVzDDfCIknerhx8XUKnstuOERPNNIinXG7v9u+ohXF67vxm4TPTEPU6lm61ZkwP3c9PCB97rhg==",
+			"requires": {
+				"call-bind": "^1.0.7"
+			}
+		},
 		"is-stream": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
 			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+		},
+		"is-string": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+			"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+			"requires": {
+				"has-tostringtag": "^1.0.0"
+			}
+		},
+		"is-symbol": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+			"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+			"requires": {
+				"has-symbols": "^1.0.2"
+			}
 		},
 		"is-text-path": {
 			"version": "2.0.0",
@@ -10388,10 +16948,48 @@
 				"text-extensions": "^2.0.0"
 			}
 		},
+		"is-typed-array": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
+			"integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+			"requires": {
+				"which-typed-array": "^1.1.14"
+			}
+		},
+		"is-unicode-supported": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.0.0.tgz",
+			"integrity": "sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q=="
+		},
+		"is-weakref": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+			"integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+			"requires": {
+				"call-bind": "^1.0.2"
+			}
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+		},
 		"isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+		},
+		"issue-parser": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.0.tgz",
+			"integrity": "sha512-jgAw78HO3gs9UrKqJNQvfDj9Ouy8Mhu40fbEJ8yXff4MW8+/Fcn9iFjyWUQ6SKbX8ipPk3X5A3AyfYHRu6uVLw==",
+			"requires": {
+				"lodash.capitalize": "^4.2.1",
+				"lodash.escaperegexp": "^4.1.2",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.uniqby": "^4.7.0"
+			}
 		},
 		"istanbul-lib-coverage": {
 			"version": "3.2.2",
@@ -10438,6 +17036,11 @@
 				"html-escaper": "^2.0.0",
 				"istanbul-lib-report": "^3.0.0"
 			}
+		},
+		"java-properties": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
+			"integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ=="
 		},
 		"jest": {
 			"version": "29.7.0",
@@ -10937,6 +17540,11 @@
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
 			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
 		},
+		"json-parse-better-errors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+		},
 		"json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -10952,6 +17560,11 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
 		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+		},
 		"json5": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -10961,6 +17574,22 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.1.tgz",
 			"integrity": "sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA=="
+		},
+		"jsonfile": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+			"requires": {
+				"graceful-fs": "^4.1.6",
+				"universalify": "^2.0.0"
+			},
+			"dependencies": {
+				"universalify": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+					"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
+				}
+			}
 		},
 		"jsonparse": {
 			"version": "1.3.1",
@@ -11162,6 +17791,33 @@
 				}
 			}
 		},
+		"load-json-file": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
+				"strip-bom": "^3.0.0"
+			},
+			"dependencies": {
+				"parse-json": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+					"integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+					"requires": {
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1"
+					}
+				},
+				"strip-bom": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+					"integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="
+				}
+			}
+		},
 		"locate-path": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -11170,15 +17826,35 @@
 				"p-locate": "^4.1.0"
 			}
 		},
+		"lodash-es": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+			"integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+		},
 		"lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
 			"integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
 		},
+		"lodash.capitalize": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+			"integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw=="
+		},
+		"lodash.escaperegexp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="
+		},
 		"lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
 			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+		},
+		"lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
 		},
 		"lodash.kebabcase": {
 			"version": "4.1.1",
@@ -11209,6 +17885,11 @@
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
 			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
+		},
+		"lodash.uniqby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+			"integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww=="
 		},
 		"lodash.upperfirst": {
 			"version": "4.3.1",
@@ -11349,6 +18030,36 @@
 				"tmpl": "1.0.5"
 			}
 		},
+		"marked": {
+			"version": "12.0.2",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+			"integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q=="
+		},
+		"marked-terminal": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.0.0.tgz",
+			"integrity": "sha512-sNEx8nn9Ktcm6pL0TnRz8tnXq/mSS0Q1FRSwJOAqw4lAB4l49UeDf85Gm1n9RPFm5qurCPjwi1StAQT2XExhZw==",
+			"requires": {
+				"ansi-escapes": "^6.2.0",
+				"chalk": "^5.3.0",
+				"cli-highlight": "^2.1.11",
+				"cli-table3": "^0.6.3",
+				"node-emoji": "^2.1.3",
+				"supports-hyperlinks": "^3.0.0"
+			},
+			"dependencies": {
+				"ansi-escapes": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
+					"integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig=="
+				},
+				"chalk": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+					"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w=="
+				}
+			}
+		},
 		"memorystream": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
@@ -11377,6 +18088,11 @@
 				"braces": "^3.0.2",
 				"picomatch": "^2.3.1"
 			}
+		},
+		"mime": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-4.0.3.tgz",
+			"integrity": "sha512-KgUb15Oorc0NEKPbvfa0wRU+PItIEZmiv+pyAO2i0oTIVTJhlzMclU7w4RXWQrSOVH5ax/p/CkIO7KI4OyFJTQ=="
 		},
 		"mime-db": {
 			"version": "1.52.0",
@@ -11414,10 +18130,41 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
+		"mz": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+			"requires": {
+				"any-promise": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"thenify-all": "^1.0.0"
+			}
+		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
+		},
+		"neo-async": {
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+		},
+		"nerf-dart": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
+			"integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g=="
+		},
+		"node-emoji": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.1.3.tgz",
+			"integrity": "sha512-E2WEOVsgs7O16zsURJ/eH8BqhF029wGpEOnv7Urwdo2wmQanOACwJQh0devF9D9RhoZru0+9JXIS0dBXIAz+lA==",
+			"requires": {
+				"@sindresorhus/is": "^4.6.0",
+				"char-regex": "^1.0.2",
+				"emojilib": "^2.4.0",
+				"skin-tone": "^2.0.0"
+			}
 		},
 		"node-int64": {
 			"version": "0.4.0",
@@ -11429,10 +18176,1566 @@
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
 			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
 		},
+		"normalize-package-data": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.1.tgz",
+			"integrity": "sha512-6rvCfeRW+OEZagAB4lMLSNuTNYZWLVtKccK79VSTf//yTY5VOCgcpH80O+bZK8Neps7pUnd5G+QlMg1yV/2iZQ==",
+			"requires": {
+				"hosted-git-info": "^7.0.0",
+				"is-core-module": "^2.8.1",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.6.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+					"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w=="
+				}
+			}
+		},
 		"normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+		},
+		"normalize-url": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.1.tgz",
+			"integrity": "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w=="
+		},
+		"npm": {
+			"version": "10.8.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-10.8.0.tgz",
+			"integrity": "sha512-wh93uRczgp7HDnPMiLXcCkv2hagdJS0zJ9KT/31d0FoXP02+qgN2AOwpaW85fxRWkinl2rELfPw+CjBXW48/jQ==",
+			"requires": {
+				"@isaacs/string-locale-compare": "^1.1.0",
+				"@npmcli/arborist": "^7.5.2",
+				"@npmcli/config": "^8.3.2",
+				"@npmcli/fs": "^3.1.1",
+				"@npmcli/map-workspaces": "^3.0.6",
+				"@npmcli/package-json": "^5.1.0",
+				"@npmcli/promise-spawn": "^7.0.2",
+				"@npmcli/redact": "^2.0.0",
+				"@npmcli/run-script": "^8.1.0",
+				"@sigstore/tuf": "^2.3.3",
+				"abbrev": "^2.0.0",
+				"archy": "~1.0.0",
+				"cacache": "^18.0.3",
+				"chalk": "^5.3.0",
+				"ci-info": "^4.0.0",
+				"cli-columns": "^4.0.0",
+				"fastest-levenshtein": "^1.0.16",
+				"fs-minipass": "^3.0.3",
+				"glob": "^10.3.15",
+				"graceful-fs": "^4.2.11",
+				"hosted-git-info": "^7.0.2",
+				"ini": "^4.1.2",
+				"init-package-json": "^6.0.3",
+				"is-cidr": "^5.0.5",
+				"json-parse-even-better-errors": "^3.0.2",
+				"libnpmaccess": "^8.0.6",
+				"libnpmdiff": "^6.1.2",
+				"libnpmexec": "^8.1.1",
+				"libnpmfund": "^5.0.10",
+				"libnpmhook": "^10.0.5",
+				"libnpmorg": "^6.0.6",
+				"libnpmpack": "^7.0.2",
+				"libnpmpublish": "^9.0.8",
+				"libnpmsearch": "^7.0.5",
+				"libnpmteam": "^6.0.5",
+				"libnpmversion": "^6.0.2",
+				"make-fetch-happen": "^13.0.1",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.1",
+				"minipass-pipeline": "^1.2.4",
+				"ms": "^2.1.2",
+				"node-gyp": "^10.1.0",
+				"nopt": "^7.2.1",
+				"normalize-package-data": "^6.0.1",
+				"npm-audit-report": "^5.0.0",
+				"npm-install-checks": "^6.3.0",
+				"npm-package-arg": "^11.0.2",
+				"npm-pick-manifest": "^9.0.1",
+				"npm-profile": "^10.0.0",
+				"npm-registry-fetch": "^17.0.1",
+				"npm-user-validate": "^2.0.1",
+				"p-map": "^4.0.0",
+				"pacote": "^18.0.6",
+				"parse-conflict-json": "^3.0.1",
+				"proc-log": "^4.2.0",
+				"qrcode-terminal": "^0.12.0",
+				"read": "^3.0.1",
+				"semver": "^7.6.2",
+				"spdx-expression-parse": "^4.0.0",
+				"ssri": "^10.0.6",
+				"supports-color": "^9.4.0",
+				"tar": "^6.2.1",
+				"text-table": "~0.2.0",
+				"tiny-relative-date": "^1.3.0",
+				"treeverse": "^3.0.0",
+				"validate-npm-package-name": "^5.0.1",
+				"which": "^4.0.0",
+				"write-file-atomic": "^5.0.1"
+			},
+			"dependencies": {
+				"@isaacs/cliui": {
+					"version": "8.0.2",
+					"bundled": true,
+					"requires": {
+						"string-width": "^5.1.2",
+						"string-width-cjs": "npm:string-width@^4.2.0",
+						"strip-ansi": "^7.0.1",
+						"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+						"wrap-ansi": "^8.1.0",
+						"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "6.0.1",
+							"bundled": true
+						},
+						"emoji-regex": {
+							"version": "9.2.2",
+							"bundled": true
+						},
+						"string-width": {
+							"version": "5.1.2",
+							"bundled": true,
+							"requires": {
+								"eastasianwidth": "^0.2.0",
+								"emoji-regex": "^9.2.2",
+								"strip-ansi": "^7.0.1"
+							}
+						},
+						"strip-ansi": {
+							"version": "7.1.0",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "^6.0.1"
+							}
+						}
+					}
+				},
+				"@isaacs/string-locale-compare": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"@npmcli/agent": {
+					"version": "2.2.2",
+					"bundled": true,
+					"requires": {
+						"agent-base": "^7.1.0",
+						"http-proxy-agent": "^7.0.0",
+						"https-proxy-agent": "^7.0.1",
+						"lru-cache": "^10.0.1",
+						"socks-proxy-agent": "^8.0.3"
+					}
+				},
+				"@npmcli/arborist": {
+					"version": "7.5.2",
+					"bundled": true,
+					"requires": {
+						"@isaacs/string-locale-compare": "^1.1.0",
+						"@npmcli/fs": "^3.1.1",
+						"@npmcli/installed-package-contents": "^2.1.0",
+						"@npmcli/map-workspaces": "^3.0.2",
+						"@npmcli/metavuln-calculator": "^7.1.1",
+						"@npmcli/name-from-folder": "^2.0.0",
+						"@npmcli/node-gyp": "^3.0.0",
+						"@npmcli/package-json": "^5.1.0",
+						"@npmcli/query": "^3.1.0",
+						"@npmcli/redact": "^2.0.0",
+						"@npmcli/run-script": "^8.1.0",
+						"bin-links": "^4.0.4",
+						"cacache": "^18.0.3",
+						"common-ancestor-path": "^1.0.1",
+						"hosted-git-info": "^7.0.2",
+						"json-parse-even-better-errors": "^3.0.2",
+						"json-stringify-nice": "^1.1.4",
+						"lru-cache": "^10.2.2",
+						"minimatch": "^9.0.4",
+						"nopt": "^7.2.1",
+						"npm-install-checks": "^6.2.0",
+						"npm-package-arg": "^11.0.2",
+						"npm-pick-manifest": "^9.0.1",
+						"npm-registry-fetch": "^17.0.1",
+						"pacote": "^18.0.6",
+						"parse-conflict-json": "^3.0.0",
+						"proc-log": "^4.2.0",
+						"proggy": "^2.0.0",
+						"promise-all-reject-late": "^1.0.0",
+						"promise-call-limit": "^3.0.1",
+						"read-package-json-fast": "^3.0.2",
+						"semver": "^7.3.7",
+						"ssri": "^10.0.6",
+						"treeverse": "^3.0.0",
+						"walk-up-path": "^3.0.1"
+					}
+				},
+				"@npmcli/config": {
+					"version": "8.3.2",
+					"bundled": true,
+					"requires": {
+						"@npmcli/map-workspaces": "^3.0.2",
+						"ci-info": "^4.0.0",
+						"ini": "^4.1.2",
+						"nopt": "^7.2.1",
+						"proc-log": "^4.2.0",
+						"read-package-json-fast": "^3.0.2",
+						"semver": "^7.3.5",
+						"walk-up-path": "^3.0.1"
+					}
+				},
+				"@npmcli/fs": {
+					"version": "3.1.1",
+					"bundled": true,
+					"requires": {
+						"semver": "^7.3.5"
+					}
+				},
+				"@npmcli/git": {
+					"version": "5.0.7",
+					"bundled": true,
+					"requires": {
+						"@npmcli/promise-spawn": "^7.0.0",
+						"lru-cache": "^10.0.1",
+						"npm-pick-manifest": "^9.0.0",
+						"proc-log": "^4.0.0",
+						"promise-inflight": "^1.0.1",
+						"promise-retry": "^2.0.1",
+						"semver": "^7.3.5",
+						"which": "^4.0.0"
+					}
+				},
+				"@npmcli/installed-package-contents": {
+					"version": "2.1.0",
+					"bundled": true,
+					"requires": {
+						"npm-bundled": "^3.0.0",
+						"npm-normalize-package-bin": "^3.0.0"
+					}
+				},
+				"@npmcli/map-workspaces": {
+					"version": "3.0.6",
+					"bundled": true,
+					"requires": {
+						"@npmcli/name-from-folder": "^2.0.0",
+						"glob": "^10.2.2",
+						"minimatch": "^9.0.0",
+						"read-package-json-fast": "^3.0.0"
+					}
+				},
+				"@npmcli/metavuln-calculator": {
+					"version": "7.1.1",
+					"bundled": true,
+					"requires": {
+						"cacache": "^18.0.0",
+						"json-parse-even-better-errors": "^3.0.0",
+						"pacote": "^18.0.0",
+						"proc-log": "^4.1.0",
+						"semver": "^7.3.5"
+					}
+				},
+				"@npmcli/name-from-folder": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"@npmcli/node-gyp": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"@npmcli/package-json": {
+					"version": "5.1.0",
+					"bundled": true,
+					"requires": {
+						"@npmcli/git": "^5.0.0",
+						"glob": "^10.2.2",
+						"hosted-git-info": "^7.0.0",
+						"json-parse-even-better-errors": "^3.0.0",
+						"normalize-package-data": "^6.0.0",
+						"proc-log": "^4.0.0",
+						"semver": "^7.5.3"
+					}
+				},
+				"@npmcli/promise-spawn": {
+					"version": "7.0.2",
+					"bundled": true,
+					"requires": {
+						"which": "^4.0.0"
+					}
+				},
+				"@npmcli/query": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"postcss-selector-parser": "^6.0.10"
+					}
+				},
+				"@npmcli/redact": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"@npmcli/run-script": {
+					"version": "8.1.0",
+					"bundled": true,
+					"requires": {
+						"@npmcli/node-gyp": "^3.0.0",
+						"@npmcli/package-json": "^5.0.0",
+						"@npmcli/promise-spawn": "^7.0.0",
+						"node-gyp": "^10.0.0",
+						"proc-log": "^4.0.0",
+						"which": "^4.0.0"
+					}
+				},
+				"@pkgjs/parseargs": {
+					"version": "0.11.0",
+					"bundled": true,
+					"optional": true
+				},
+				"@sigstore/bundle": {
+					"version": "2.3.1",
+					"bundled": true,
+					"requires": {
+						"@sigstore/protobuf-specs": "^0.3.1"
+					}
+				},
+				"@sigstore/core": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"@sigstore/protobuf-specs": {
+					"version": "0.3.2",
+					"bundled": true
+				},
+				"@sigstore/sign": {
+					"version": "2.3.1",
+					"bundled": true,
+					"requires": {
+						"@sigstore/bundle": "^2.3.0",
+						"@sigstore/core": "^1.0.0",
+						"@sigstore/protobuf-specs": "^0.3.1",
+						"make-fetch-happen": "^13.0.1",
+						"proc-log": "^4.2.0",
+						"promise-retry": "^2.0.1"
+					}
+				},
+				"@sigstore/tuf": {
+					"version": "2.3.3",
+					"bundled": true,
+					"requires": {
+						"@sigstore/protobuf-specs": "^0.3.0",
+						"tuf-js": "^2.2.1"
+					}
+				},
+				"@sigstore/verify": {
+					"version": "1.2.0",
+					"bundled": true,
+					"requires": {
+						"@sigstore/bundle": "^2.3.1",
+						"@sigstore/core": "^1.1.0",
+						"@sigstore/protobuf-specs": "^0.3.1"
+					}
+				},
+				"@tufjs/canonical-json": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"@tufjs/models": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"@tufjs/canonical-json": "2.0.0",
+						"minimatch": "^9.0.4"
+					}
+				},
+				"abbrev": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"agent-base": {
+					"version": "7.1.1",
+					"bundled": true,
+					"requires": {
+						"debug": "^4.3.4"
+					}
+				},
+				"aggregate-error": {
+					"version": "3.1.0",
+					"bundled": true,
+					"requires": {
+						"clean-stack": "^2.0.0",
+						"indent-string": "^4.0.0"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.1",
+					"bundled": true
+				},
+				"ansi-styles": {
+					"version": "6.2.1",
+					"bundled": true
+				},
+				"aproba": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"archy": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"balanced-match": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"bin-links": {
+					"version": "4.0.4",
+					"bundled": true,
+					"requires": {
+						"cmd-shim": "^6.0.0",
+						"npm-normalize-package-bin": "^3.0.0",
+						"read-cmd-shim": "^4.0.0",
+						"write-file-atomic": "^5.0.0"
+					}
+				},
+				"binary-extensions": {
+					"version": "2.3.0",
+					"bundled": true
+				},
+				"brace-expansion": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"cacache": {
+					"version": "18.0.3",
+					"bundled": true,
+					"requires": {
+						"@npmcli/fs": "^3.1.0",
+						"fs-minipass": "^3.0.0",
+						"glob": "^10.2.2",
+						"lru-cache": "^10.0.1",
+						"minipass": "^7.0.3",
+						"minipass-collect": "^2.0.1",
+						"minipass-flush": "^1.0.5",
+						"minipass-pipeline": "^1.2.4",
+						"p-map": "^4.0.0",
+						"ssri": "^10.0.0",
+						"tar": "^6.1.11",
+						"unique-filename": "^3.0.0"
+					}
+				},
+				"chalk": {
+					"version": "5.3.0",
+					"bundled": true
+				},
+				"chownr": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"ci-info": {
+					"version": "4.0.0",
+					"bundled": true
+				},
+				"cidr-regex": {
+					"version": "4.0.5",
+					"bundled": true,
+					"requires": {
+						"ip-regex": "^5.0.0"
+					}
+				},
+				"clean-stack": {
+					"version": "2.2.0",
+					"bundled": true
+				},
+				"cli-columns": {
+					"version": "4.0.0",
+					"bundled": true,
+					"requires": {
+						"string-width": "^4.2.3",
+						"strip-ansi": "^6.0.1"
+					}
+				},
+				"cmd-shim": {
+					"version": "6.0.3",
+					"bundled": true
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"bundled": true
+				},
+				"common-ancestor-path": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"cross-spawn": {
+					"version": "7.0.3",
+					"bundled": true,
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					},
+					"dependencies": {
+						"which": {
+							"version": "2.0.2",
+							"bundled": true,
+							"requires": {
+								"isexe": "^2.0.0"
+							}
+						}
+					}
+				},
+				"cssesc": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"debug": {
+					"version": "4.3.4",
+					"bundled": true,
+					"requires": {
+						"ms": "2.1.2"
+					},
+					"dependencies": {
+						"ms": {
+							"version": "2.1.2",
+							"bundled": true
+						}
+					}
+				},
+				"diff": {
+					"version": "5.2.0",
+					"bundled": true
+				},
+				"eastasianwidth": {
+					"version": "0.2.0",
+					"bundled": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"bundled": true
+				},
+				"encoding": {
+					"version": "0.1.13",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"iconv-lite": "^0.6.2"
+					}
+				},
+				"env-paths": {
+					"version": "2.2.1",
+					"bundled": true
+				},
+				"err-code": {
+					"version": "2.0.3",
+					"bundled": true
+				},
+				"exponential-backoff": {
+					"version": "3.1.1",
+					"bundled": true
+				},
+				"fastest-levenshtein": {
+					"version": "1.0.16",
+					"bundled": true
+				},
+				"foreground-child": {
+					"version": "3.1.1",
+					"bundled": true,
+					"requires": {
+						"cross-spawn": "^7.0.0",
+						"signal-exit": "^4.0.1"
+					}
+				},
+				"fs-minipass": {
+					"version": "3.0.3",
+					"bundled": true,
+					"requires": {
+						"minipass": "^7.0.3"
+					}
+				},
+				"function-bind": {
+					"version": "1.1.2",
+					"bundled": true
+				},
+				"glob": {
+					"version": "10.3.15",
+					"bundled": true,
+					"requires": {
+						"foreground-child": "^3.1.0",
+						"jackspeak": "^2.3.6",
+						"minimatch": "^9.0.1",
+						"minipass": "^7.0.4",
+						"path-scurry": "^1.11.0"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.2.11",
+					"bundled": true
+				},
+				"hasown": {
+					"version": "2.0.2",
+					"bundled": true,
+					"requires": {
+						"function-bind": "^1.1.2"
+					}
+				},
+				"hosted-git-info": {
+					"version": "7.0.2",
+					"bundled": true,
+					"requires": {
+						"lru-cache": "^10.0.1"
+					}
+				},
+				"http-cache-semantics": {
+					"version": "4.1.1",
+					"bundled": true
+				},
+				"http-proxy-agent": {
+					"version": "7.0.2",
+					"bundled": true,
+					"requires": {
+						"agent-base": "^7.1.0",
+						"debug": "^4.3.4"
+					}
+				},
+				"https-proxy-agent": {
+					"version": "7.0.4",
+					"bundled": true,
+					"requires": {
+						"agent-base": "^7.0.2",
+						"debug": "4"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.6.3",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3.0.0"
+					}
+				},
+				"ignore-walk": {
+					"version": "6.0.5",
+					"bundled": true,
+					"requires": {
+						"minimatch": "^9.0.0"
+					}
+				},
+				"imurmurhash": {
+					"version": "0.1.4",
+					"bundled": true
+				},
+				"indent-string": {
+					"version": "4.0.0",
+					"bundled": true
+				},
+				"ini": {
+					"version": "4.1.2",
+					"bundled": true
+				},
+				"init-package-json": {
+					"version": "6.0.3",
+					"bundled": true,
+					"requires": {
+						"@npmcli/package-json": "^5.0.0",
+						"npm-package-arg": "^11.0.0",
+						"promzard": "^1.0.0",
+						"read": "^3.0.1",
+						"semver": "^7.3.5",
+						"validate-npm-package-license": "^3.0.4",
+						"validate-npm-package-name": "^5.0.0"
+					}
+				},
+				"ip-address": {
+					"version": "9.0.5",
+					"bundled": true,
+					"requires": {
+						"jsbn": "1.1.0",
+						"sprintf-js": "^1.1.3"
+					}
+				},
+				"ip-regex": {
+					"version": "5.0.0",
+					"bundled": true
+				},
+				"is-cidr": {
+					"version": "5.0.5",
+					"bundled": true,
+					"requires": {
+						"cidr-regex": "^4.0.4"
+					}
+				},
+				"is-core-module": {
+					"version": "2.13.1",
+					"bundled": true,
+					"requires": {
+						"hasown": "^2.0.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"is-lambda": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"jackspeak": {
+					"version": "2.3.6",
+					"bundled": true,
+					"requires": {
+						"@isaacs/cliui": "^8.0.2",
+						"@pkgjs/parseargs": "^0.11.0"
+					}
+				},
+				"jsbn": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"json-parse-even-better-errors": {
+					"version": "3.0.2",
+					"bundled": true
+				},
+				"json-stringify-nice": {
+					"version": "1.1.4",
+					"bundled": true
+				},
+				"jsonparse": {
+					"version": "1.3.1",
+					"bundled": true
+				},
+				"just-diff": {
+					"version": "6.0.2",
+					"bundled": true
+				},
+				"just-diff-apply": {
+					"version": "5.5.0",
+					"bundled": true
+				},
+				"libnpmaccess": {
+					"version": "8.0.6",
+					"bundled": true,
+					"requires": {
+						"npm-package-arg": "^11.0.2",
+						"npm-registry-fetch": "^17.0.1"
+					}
+				},
+				"libnpmdiff": {
+					"version": "6.1.2",
+					"bundled": true,
+					"requires": {
+						"@npmcli/arborist": "^7.5.2",
+						"@npmcli/installed-package-contents": "^2.1.0",
+						"binary-extensions": "^2.3.0",
+						"diff": "^5.1.0",
+						"minimatch": "^9.0.4",
+						"npm-package-arg": "^11.0.2",
+						"pacote": "^18.0.6",
+						"tar": "^6.2.1"
+					}
+				},
+				"libnpmexec": {
+					"version": "8.1.1",
+					"bundled": true,
+					"requires": {
+						"@npmcli/arborist": "^7.5.2",
+						"@npmcli/run-script": "^8.1.0",
+						"ci-info": "^4.0.0",
+						"npm-package-arg": "^11.0.2",
+						"pacote": "^18.0.6",
+						"proc-log": "^4.2.0",
+						"read": "^3.0.1",
+						"read-package-json-fast": "^3.0.2",
+						"semver": "^7.3.7",
+						"walk-up-path": "^3.0.1"
+					}
+				},
+				"libnpmfund": {
+					"version": "5.0.10",
+					"bundled": true,
+					"requires": {
+						"@npmcli/arborist": "^7.5.2"
+					}
+				},
+				"libnpmhook": {
+					"version": "10.0.5",
+					"bundled": true,
+					"requires": {
+						"aproba": "^2.0.0",
+						"npm-registry-fetch": "^17.0.1"
+					}
+				},
+				"libnpmorg": {
+					"version": "6.0.6",
+					"bundled": true,
+					"requires": {
+						"aproba": "^2.0.0",
+						"npm-registry-fetch": "^17.0.1"
+					}
+				},
+				"libnpmpack": {
+					"version": "7.0.2",
+					"bundled": true,
+					"requires": {
+						"@npmcli/arborist": "^7.5.2",
+						"@npmcli/run-script": "^8.1.0",
+						"npm-package-arg": "^11.0.2",
+						"pacote": "^18.0.6"
+					}
+				},
+				"libnpmpublish": {
+					"version": "9.0.8",
+					"bundled": true,
+					"requires": {
+						"ci-info": "^4.0.0",
+						"normalize-package-data": "^6.0.1",
+						"npm-package-arg": "^11.0.2",
+						"npm-registry-fetch": "^17.0.1",
+						"proc-log": "^4.2.0",
+						"semver": "^7.3.7",
+						"sigstore": "^2.2.0",
+						"ssri": "^10.0.6"
+					}
+				},
+				"libnpmsearch": {
+					"version": "7.0.5",
+					"bundled": true,
+					"requires": {
+						"npm-registry-fetch": "^17.0.1"
+					}
+				},
+				"libnpmteam": {
+					"version": "6.0.5",
+					"bundled": true,
+					"requires": {
+						"aproba": "^2.0.0",
+						"npm-registry-fetch": "^17.0.1"
+					}
+				},
+				"libnpmversion": {
+					"version": "6.0.2",
+					"bundled": true,
+					"requires": {
+						"@npmcli/git": "^5.0.7",
+						"@npmcli/run-script": "^8.1.0",
+						"json-parse-even-better-errors": "^3.0.2",
+						"proc-log": "^4.2.0",
+						"semver": "^7.3.7"
+					}
+				},
+				"lru-cache": {
+					"version": "10.2.2",
+					"bundled": true
+				},
+				"make-fetch-happen": {
+					"version": "13.0.1",
+					"bundled": true,
+					"requires": {
+						"@npmcli/agent": "^2.0.0",
+						"cacache": "^18.0.0",
+						"http-cache-semantics": "^4.1.1",
+						"is-lambda": "^1.0.1",
+						"minipass": "^7.0.2",
+						"minipass-fetch": "^3.0.0",
+						"minipass-flush": "^1.0.5",
+						"minipass-pipeline": "^1.2.4",
+						"negotiator": "^0.6.3",
+						"proc-log": "^4.2.0",
+						"promise-retry": "^2.0.1",
+						"ssri": "^10.0.0"
+					}
+				},
+				"minimatch": {
+					"version": "9.0.4",
+					"bundled": true,
+					"requires": {
+						"brace-expansion": "^2.0.1"
+					}
+				},
+				"minipass": {
+					"version": "7.1.1",
+					"bundled": true
+				},
+				"minipass-collect": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"minipass": "^7.0.3"
+					}
+				},
+				"minipass-fetch": {
+					"version": "3.0.5",
+					"bundled": true,
+					"requires": {
+						"encoding": "^0.1.13",
+						"minipass": "^7.0.3",
+						"minipass-sized": "^1.0.3",
+						"minizlib": "^2.1.2"
+					}
+				},
+				"minipass-flush": {
+					"version": "1.0.5",
+					"bundled": true,
+					"requires": {
+						"minipass": "^3.0.0"
+					},
+					"dependencies": {
+						"minipass": {
+							"version": "3.3.6",
+							"bundled": true,
+							"requires": {
+								"yallist": "^4.0.0"
+							}
+						}
+					}
+				},
+				"minipass-json-stream": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"jsonparse": "^1.3.1",
+						"minipass": "^3.0.0"
+					},
+					"dependencies": {
+						"minipass": {
+							"version": "3.3.6",
+							"bundled": true,
+							"requires": {
+								"yallist": "^4.0.0"
+							}
+						}
+					}
+				},
+				"minipass-pipeline": {
+					"version": "1.2.4",
+					"bundled": true,
+					"requires": {
+						"minipass": "^3.0.0"
+					},
+					"dependencies": {
+						"minipass": {
+							"version": "3.3.6",
+							"bundled": true,
+							"requires": {
+								"yallist": "^4.0.0"
+							}
+						}
+					}
+				},
+				"minipass-sized": {
+					"version": "1.0.3",
+					"bundled": true,
+					"requires": {
+						"minipass": "^3.0.0"
+					},
+					"dependencies": {
+						"minipass": {
+							"version": "3.3.6",
+							"bundled": true,
+							"requires": {
+								"yallist": "^4.0.0"
+							}
+						}
+					}
+				},
+				"minizlib": {
+					"version": "2.1.2",
+					"bundled": true,
+					"requires": {
+						"minipass": "^3.0.0",
+						"yallist": "^4.0.0"
+					},
+					"dependencies": {
+						"minipass": {
+							"version": "3.3.6",
+							"bundled": true,
+							"requires": {
+								"yallist": "^4.0.0"
+							}
+						}
+					}
+				},
+				"mkdirp": {
+					"version": "1.0.4",
+					"bundled": true
+				},
+				"ms": {
+					"version": "2.1.3",
+					"bundled": true
+				},
+				"mute-stream": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"negotiator": {
+					"version": "0.6.3",
+					"bundled": true
+				},
+				"node-gyp": {
+					"version": "10.1.0",
+					"bundled": true,
+					"requires": {
+						"env-paths": "^2.2.0",
+						"exponential-backoff": "^3.1.1",
+						"glob": "^10.3.10",
+						"graceful-fs": "^4.2.6",
+						"make-fetch-happen": "^13.0.0",
+						"nopt": "^7.0.0",
+						"proc-log": "^3.0.0",
+						"semver": "^7.3.5",
+						"tar": "^6.1.2",
+						"which": "^4.0.0"
+					},
+					"dependencies": {
+						"proc-log": {
+							"version": "3.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"nopt": {
+					"version": "7.2.1",
+					"bundled": true,
+					"requires": {
+						"abbrev": "^2.0.0"
+					}
+				},
+				"normalize-package-data": {
+					"version": "6.0.1",
+					"bundled": true,
+					"requires": {
+						"hosted-git-info": "^7.0.0",
+						"is-core-module": "^2.8.1",
+						"semver": "^7.3.5",
+						"validate-npm-package-license": "^3.0.4"
+					}
+				},
+				"npm-audit-report": {
+					"version": "5.0.0",
+					"bundled": true
+				},
+				"npm-bundled": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"npm-normalize-package-bin": "^3.0.0"
+					}
+				},
+				"npm-install-checks": {
+					"version": "6.3.0",
+					"bundled": true,
+					"requires": {
+						"semver": "^7.1.1"
+					}
+				},
+				"npm-normalize-package-bin": {
+					"version": "3.0.1",
+					"bundled": true
+				},
+				"npm-package-arg": {
+					"version": "11.0.2",
+					"bundled": true,
+					"requires": {
+						"hosted-git-info": "^7.0.0",
+						"proc-log": "^4.0.0",
+						"semver": "^7.3.5",
+						"validate-npm-package-name": "^5.0.0"
+					}
+				},
+				"npm-packlist": {
+					"version": "8.0.2",
+					"bundled": true,
+					"requires": {
+						"ignore-walk": "^6.0.4"
+					}
+				},
+				"npm-pick-manifest": {
+					"version": "9.0.1",
+					"bundled": true,
+					"requires": {
+						"npm-install-checks": "^6.0.0",
+						"npm-normalize-package-bin": "^3.0.0",
+						"npm-package-arg": "^11.0.0",
+						"semver": "^7.3.5"
+					}
+				},
+				"npm-profile": {
+					"version": "10.0.0",
+					"bundled": true,
+					"requires": {
+						"npm-registry-fetch": "^17.0.1",
+						"proc-log": "^4.0.0"
+					}
+				},
+				"npm-registry-fetch": {
+					"version": "17.0.1",
+					"bundled": true,
+					"requires": {
+						"@npmcli/redact": "^2.0.0",
+						"make-fetch-happen": "^13.0.0",
+						"minipass": "^7.0.2",
+						"minipass-fetch": "^3.0.0",
+						"minipass-json-stream": "^1.0.1",
+						"minizlib": "^2.1.2",
+						"npm-package-arg": "^11.0.0",
+						"proc-log": "^4.0.0"
+					}
+				},
+				"npm-user-validate": {
+					"version": "2.0.1",
+					"bundled": true
+				},
+				"p-map": {
+					"version": "4.0.0",
+					"bundled": true,
+					"requires": {
+						"aggregate-error": "^3.0.0"
+					}
+				},
+				"pacote": {
+					"version": "18.0.6",
+					"bundled": true,
+					"requires": {
+						"@npmcli/git": "^5.0.0",
+						"@npmcli/installed-package-contents": "^2.0.1",
+						"@npmcli/package-json": "^5.1.0",
+						"@npmcli/promise-spawn": "^7.0.0",
+						"@npmcli/run-script": "^8.0.0",
+						"cacache": "^18.0.0",
+						"fs-minipass": "^3.0.0",
+						"minipass": "^7.0.2",
+						"npm-package-arg": "^11.0.0",
+						"npm-packlist": "^8.0.0",
+						"npm-pick-manifest": "^9.0.0",
+						"npm-registry-fetch": "^17.0.0",
+						"proc-log": "^4.0.0",
+						"promise-retry": "^2.0.1",
+						"sigstore": "^2.2.0",
+						"ssri": "^10.0.0",
+						"tar": "^6.1.11"
+					}
+				},
+				"parse-conflict-json": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"json-parse-even-better-errors": "^3.0.0",
+						"just-diff": "^6.0.0",
+						"just-diff-apply": "^5.2.0"
+					}
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"bundled": true
+				},
+				"path-scurry": {
+					"version": "1.11.1",
+					"bundled": true,
+					"requires": {
+						"lru-cache": "^10.2.0",
+						"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+					}
+				},
+				"postcss-selector-parser": {
+					"version": "6.0.16",
+					"bundled": true,
+					"requires": {
+						"cssesc": "^3.0.0",
+						"util-deprecate": "^1.0.2"
+					}
+				},
+				"proc-log": {
+					"version": "4.2.0",
+					"bundled": true
+				},
+				"proggy": {
+					"version": "2.0.0",
+					"bundled": true
+				},
+				"promise-all-reject-late": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"promise-call-limit": {
+					"version": "3.0.1",
+					"bundled": true
+				},
+				"promise-inflight": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"promise-retry": {
+					"version": "2.0.1",
+					"bundled": true,
+					"requires": {
+						"err-code": "^2.0.2",
+						"retry": "^0.12.0"
+					}
+				},
+				"promzard": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"read": "^3.0.1"
+					}
+				},
+				"qrcode-terminal": {
+					"version": "0.12.0",
+					"bundled": true
+				},
+				"read": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"mute-stream": "^1.0.0"
+					}
+				},
+				"read-cmd-shim": {
+					"version": "4.0.0",
+					"bundled": true
+				},
+				"read-package-json-fast": {
+					"version": "3.0.2",
+					"bundled": true,
+					"requires": {
+						"json-parse-even-better-errors": "^3.0.0",
+						"npm-normalize-package-bin": "^3.0.0"
+					}
+				},
+				"retry": {
+					"version": "0.12.0",
+					"bundled": true
+				},
+				"safer-buffer": {
+					"version": "2.1.2",
+					"bundled": true,
+					"optional": true
+				},
+				"semver": {
+					"version": "7.6.2",
+					"bundled": true
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"bundled": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"signal-exit": {
+					"version": "4.1.0",
+					"bundled": true
+				},
+				"sigstore": {
+					"version": "2.3.0",
+					"bundled": true,
+					"requires": {
+						"@sigstore/bundle": "^2.3.1",
+						"@sigstore/core": "^1.0.0",
+						"@sigstore/protobuf-specs": "^0.3.1",
+						"@sigstore/sign": "^2.3.0",
+						"@sigstore/tuf": "^2.3.1",
+						"@sigstore/verify": "^1.2.0"
+					}
+				},
+				"smart-buffer": {
+					"version": "4.2.0",
+					"bundled": true
+				},
+				"socks": {
+					"version": "2.8.3",
+					"bundled": true,
+					"requires": {
+						"ip-address": "^9.0.5",
+						"smart-buffer": "^4.2.0"
+					}
+				},
+				"socks-proxy-agent": {
+					"version": "8.0.3",
+					"bundled": true,
+					"requires": {
+						"agent-base": "^7.1.1",
+						"debug": "^4.3.4",
+						"socks": "^2.7.1"
+					}
+				},
+				"spdx-correct": {
+					"version": "3.2.0",
+					"bundled": true,
+					"requires": {
+						"spdx-expression-parse": "^3.0.0",
+						"spdx-license-ids": "^3.0.0"
+					},
+					"dependencies": {
+						"spdx-expression-parse": {
+							"version": "3.0.1",
+							"bundled": true,
+							"requires": {
+								"spdx-exceptions": "^2.1.0",
+								"spdx-license-ids": "^3.0.0"
+							}
+						}
+					}
+				},
+				"spdx-exceptions": {
+					"version": "2.5.0",
+					"bundled": true
+				},
+				"spdx-expression-parse": {
+					"version": "4.0.0",
+					"bundled": true,
+					"requires": {
+						"spdx-exceptions": "^2.1.0",
+						"spdx-license-ids": "^3.0.0"
+					}
+				},
+				"spdx-license-ids": {
+					"version": "3.0.17",
+					"bundled": true
+				},
+				"sprintf-js": {
+					"version": "1.1.3",
+					"bundled": true
+				},
+				"ssri": {
+					"version": "10.0.6",
+					"bundled": true,
+					"requires": {
+						"minipass": "^7.0.3"
+					}
+				},
+				"string-width": {
+					"version": "4.2.3",
+					"bundled": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.1"
+					}
+				},
+				"string-width-cjs": {
+					"version": "npm:string-width@4.2.3",
+					"bundled": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.1"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.1",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "^5.0.1"
+					}
+				},
+				"strip-ansi-cjs": {
+					"version": "npm:strip-ansi@6.0.1",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "^5.0.1"
+					}
+				},
+				"supports-color": {
+					"version": "9.4.0",
+					"bundled": true
+				},
+				"tar": {
+					"version": "6.2.1",
+					"bundled": true,
+					"requires": {
+						"chownr": "^2.0.0",
+						"fs-minipass": "^2.0.0",
+						"minipass": "^5.0.0",
+						"minizlib": "^2.1.1",
+						"mkdirp": "^1.0.3",
+						"yallist": "^4.0.0"
+					},
+					"dependencies": {
+						"fs-minipass": {
+							"version": "2.1.0",
+							"bundled": true,
+							"requires": {
+								"minipass": "^3.0.0"
+							},
+							"dependencies": {
+								"minipass": {
+									"version": "3.3.6",
+									"bundled": true,
+									"requires": {
+										"yallist": "^4.0.0"
+									}
+								}
+							}
+						},
+						"minipass": {
+							"version": "5.0.0",
+							"bundled": true
+						}
+					}
+				},
+				"text-table": {
+					"version": "0.2.0",
+					"bundled": true
+				},
+				"tiny-relative-date": {
+					"version": "1.3.0",
+					"bundled": true
+				},
+				"treeverse": {
+					"version": "3.0.0",
+					"bundled": true
+				},
+				"tuf-js": {
+					"version": "2.2.1",
+					"bundled": true,
+					"requires": {
+						"@tufjs/models": "2.0.1",
+						"debug": "^4.3.4",
+						"make-fetch-happen": "^13.0.1"
+					}
+				},
+				"unique-filename": {
+					"version": "3.0.0",
+					"bundled": true,
+					"requires": {
+						"unique-slug": "^4.0.0"
+					}
+				},
+				"unique-slug": {
+					"version": "4.0.0",
+					"bundled": true,
+					"requires": {
+						"imurmurhash": "^0.1.4"
+					}
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"validate-npm-package-license": {
+					"version": "3.0.4",
+					"bundled": true,
+					"requires": {
+						"spdx-correct": "^3.0.0",
+						"spdx-expression-parse": "^3.0.0"
+					},
+					"dependencies": {
+						"spdx-expression-parse": {
+							"version": "3.0.1",
+							"bundled": true,
+							"requires": {
+								"spdx-exceptions": "^2.1.0",
+								"spdx-license-ids": "^3.0.0"
+							}
+						}
+					}
+				},
+				"validate-npm-package-name": {
+					"version": "5.0.1",
+					"bundled": true
+				},
+				"walk-up-path": {
+					"version": "3.0.1",
+					"bundled": true
+				},
+				"which": {
+					"version": "4.0.0",
+					"bundled": true,
+					"requires": {
+						"isexe": "^3.1.1"
+					},
+					"dependencies": {
+						"isexe": {
+							"version": "3.1.1",
+							"bundled": true
+						}
+					}
+				},
+				"wrap-ansi": {
+					"version": "8.1.0",
+					"bundled": true,
+					"requires": {
+						"ansi-styles": "^6.1.0",
+						"string-width": "^5.0.1",
+						"strip-ansi": "^7.0.1"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "6.0.1",
+							"bundled": true
+						},
+						"emoji-regex": {
+							"version": "9.2.2",
+							"bundled": true
+						},
+						"string-width": {
+							"version": "5.1.2",
+							"bundled": true,
+							"requires": {
+								"eastasianwidth": "^0.2.0",
+								"emoji-regex": "^9.2.2",
+								"strip-ansi": "^7.0.1"
+							}
+						},
+						"strip-ansi": {
+							"version": "7.1.0",
+							"bundled": true,
+							"requires": {
+								"ansi-regex": "^6.0.1"
+							}
+						}
+					}
+				},
+				"wrap-ansi-cjs": {
+					"version": "npm:wrap-ansi@7.0.0",
+					"bundled": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "4.3.0",
+							"bundled": true,
+							"requires": {
+								"color-convert": "^2.0.1"
+							}
+						}
+					}
+				},
+				"write-file-atomic": {
+					"version": "5.0.1",
+					"bundled": true,
+					"requires": {
+						"imurmurhash": "^0.1.4",
+						"signal-exit": "^4.0.1"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"bundled": true
+				}
+			}
 		},
 		"npm-normalize-package-bin": {
 			"version": "3.0.1",
@@ -11494,6 +19797,27 @@
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
 		},
+		"object-inspect": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+			"integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ=="
+		},
+		"object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+		},
+		"object.assign": {
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+			"integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+			"requires": {
+				"call-bind": "^1.0.5",
+				"define-properties": "^1.2.1",
+				"has-symbols": "^1.0.3",
+				"object-keys": "^1.1.1"
+			}
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -11523,6 +19847,24 @@
 				"type-check": "^0.4.0"
 			}
 		},
+		"p-each-series": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
+			"integrity": "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw=="
+		},
+		"p-filter": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-filter/-/p-filter-4.1.0.tgz",
+			"integrity": "sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw==",
+			"requires": {
+				"p-map": "^7.0.1"
+			}
+		},
+		"p-is-promise": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
+			"integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ=="
+		},
 		"p-limit": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -11549,6 +19891,16 @@
 				}
 			}
 		},
+		"p-map": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.2.tgz",
+			"integrity": "sha512-z4cYYMMdKHzw4O5UkWJImbZynVIo0lSGTXc7bzB1e/rrDqkgGUNysK/o4bTr+0+xKvvLoTyGqYC4Fgljy9qe1Q=="
+		},
+		"p-reduce": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-3.0.0.tgz",
+			"integrity": "sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q=="
+		},
 		"p-try": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -11573,12 +19925,32 @@
 				"lines-and-columns": "^1.1.6"
 			}
 		},
+		"parse-ms": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+			"integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw=="
+		},
 		"parse5": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
 			"integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
 			"requires": {
 				"entities": "^4.4.0"
+			}
+		},
+		"parse5-htmlparser2-tree-adapter": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+			"integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+			"requires": {
+				"parse5": "^6.0.1"
+			},
+			"dependencies": {
+				"parse5": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+					"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="
+				}
 			}
 		},
 		"path-exists": {
@@ -11621,10 +19993,69 @@
 			"resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
 			"integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g=="
 		},
+		"pify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg=="
+		},
 		"pirates": {
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
 			"integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ=="
+		},
+		"pkg-conf": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+			"integrity": "sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==",
+			"requires": {
+				"find-up": "^2.0.0",
+				"load-json-file": "^4.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+					"requires": {
+						"p-locate": "^2.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+					"requires": {
+						"p-try": "^1.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+					"requires": {
+						"p-limit": "^1.1.0"
+					}
+				},
+				"p-try": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+					"integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww=="
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="
+				}
+			}
 		},
 		"pkg-dir": {
 			"version": "4.2.0",
@@ -11633,6 +20064,11 @@
 			"requires": {
 				"find-up": "^4.0.0"
 			}
+		},
+		"possible-typed-array-names": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+			"integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q=="
 		},
 		"prelude-ls": {
 			"version": "1.2.1",
@@ -11661,6 +20097,19 @@
 				}
 			}
 		},
+		"pretty-ms": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.0.0.tgz",
+			"integrity": "sha512-E9e9HJ9R9NasGOgPaPE8VMeiPKAyWR5jcFpNnwIejslIhWqdqOrb2wShBsncMPUb+BcCd2OPYfh7p2W6oemTng==",
+			"requires": {
+				"parse-ms": "^4.0.0"
+			}
+		},
+		"process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+		},
 		"prompts": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -11669,6 +20118,11 @@
 				"kleur": "^3.0.3",
 				"sisteransi": "^1.0.5"
 			}
+		},
+		"proto-list": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+			"integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
 		},
 		"psl": {
 			"version": "1.9.0",
@@ -11710,6 +20164,29 @@
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
 		},
+		"rc": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"requires": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"dependencies": {
+				"ini": {
+					"version": "1.3.8",
+					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+					"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
+				}
+			}
+		},
 		"react-is": {
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
@@ -11731,10 +20208,106 @@
 				}
 			}
 		},
+		"read-package-up": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+			"integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+			"requires": {
+				"find-up-simple": "^1.0.0",
+				"read-pkg": "^9.0.0",
+				"type-fest": "^4.6.0"
+			},
+			"dependencies": {
+				"type-fest": {
+					"version": "4.18.2",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
+					"integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg=="
+				}
+			}
+		},
+		"read-pkg": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+			"integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+			"requires": {
+				"@types/normalize-package-data": "^2.4.3",
+				"normalize-package-data": "^6.0.0",
+				"parse-json": "^8.0.0",
+				"type-fest": "^4.6.0",
+				"unicorn-magic": "^0.1.0"
+			},
+			"dependencies": {
+				"parse-json": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.1.0.tgz",
+					"integrity": "sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==",
+					"requires": {
+						"@babel/code-frame": "^7.22.13",
+						"index-to-position": "^0.1.2",
+						"type-fest": "^4.7.1"
+					}
+				},
+				"type-fest": {
+					"version": "4.18.2",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
+					"integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg=="
+				}
+			}
+		},
+		"read-pkg-up": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-11.0.0.tgz",
+			"integrity": "sha512-LOVbvF1Q0SZdjClSefZ0Nz5z8u+tIE7mV5NibzmE9VYmDe9CaBbAVtz1veOSZbofrdsilxuDAYnFenukZVp8/Q==",
+			"requires": {
+				"find-up-simple": "^1.0.0",
+				"read-pkg": "^9.0.0",
+				"type-fest": "^4.6.0"
+			},
+			"dependencies": {
+				"type-fest": {
+					"version": "4.18.2",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
+					"integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg=="
+				}
+			}
+		},
+		"readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
 		"regexp-to-ast": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
 			"integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw=="
+		},
+		"regexp.prototype.flags": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
+			"integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
+			"requires": {
+				"call-bind": "^1.0.6",
+				"define-properties": "^1.2.1",
+				"es-errors": "^1.3.0",
+				"set-function-name": "^2.0.1"
+			}
+		},
+		"registry-auth-token": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.2.tgz",
+			"integrity": "sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==",
+			"requires": {
+				"@pnpm/npm-conf": "^2.1.0"
+			}
 		},
 		"require-directory": {
 			"version": "2.1.1",
@@ -11814,6 +20387,39 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
+		"safe-array-concat": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
+			"integrity": "sha512-vj6RsCsWBCf19jIeHEfkRMw8DPiBb+DMXklQ/1SGDHOMlHdPUkZXFQ2YdplS23zESTijAcurb1aSgJA3AgMu1Q==",
+			"requires": {
+				"call-bind": "^1.0.7",
+				"get-intrinsic": "^1.2.4",
+				"has-symbols": "^1.0.3",
+				"isarray": "^2.0.5"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+					"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+				}
+			}
+		},
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+		},
+		"safe-regex-test": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
+			"integrity": "sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==",
+			"requires": {
+				"call-bind": "^1.0.6",
+				"es-errors": "^1.3.0",
+				"is-regex": "^1.1.4"
+			}
+		},
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -11827,10 +20433,141 @@
 				"xmlchars": "^2.2.0"
 			}
 		},
+		"semantic-release": {
+			"version": "23.1.1",
+			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-23.1.1.tgz",
+			"integrity": "sha512-qqJDBhbtHsjUEMsojWKGuL5lQFCJuPtiXKEIlFKyTzDDGTAE/oyvznaP8GeOr5PvcqBJ6LQz4JCENWPLeehSpA==",
+			"requires": {
+				"@semantic-release/commit-analyzer": "^12.0.0",
+				"@semantic-release/error": "^4.0.0",
+				"@semantic-release/github": "^10.0.0",
+				"@semantic-release/npm": "^12.0.0",
+				"@semantic-release/release-notes-generator": "^13.0.0",
+				"aggregate-error": "^5.0.0",
+				"cosmiconfig": "^9.0.0",
+				"debug": "^4.0.0",
+				"env-ci": "^11.0.0",
+				"execa": "^9.0.0",
+				"figures": "^6.0.0",
+				"find-versions": "^6.0.0",
+				"get-stream": "^6.0.0",
+				"git-log-parser": "^1.2.0",
+				"hook-std": "^3.0.0",
+				"hosted-git-info": "^7.0.0",
+				"import-from-esm": "^1.3.1",
+				"lodash-es": "^4.17.21",
+				"marked": "^12.0.0",
+				"marked-terminal": "^7.0.0",
+				"micromatch": "^4.0.2",
+				"p-each-series": "^3.0.0",
+				"p-reduce": "^3.0.0",
+				"read-package-up": "^11.0.0",
+				"resolve-from": "^5.0.0",
+				"semver": "^7.3.2",
+				"semver-diff": "^4.0.0",
+				"signale": "^1.2.1",
+				"yargs": "^17.5.1"
+			},
+			"dependencies": {
+				"@sindresorhus/merge-streams": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+					"integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="
+				},
+				"execa": {
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-9.1.0.tgz",
+					"integrity": "sha512-lSgHc4Elo2m6bUDhc3Hl/VxvUDJdQWI40RZ4KMY9bKRc+hgMOT7II/JjbNDhI8VnMtrCb7U/fhpJIkLORZozWw==",
+					"requires": {
+						"@sindresorhus/merge-streams": "^4.0.0",
+						"cross-spawn": "^7.0.3",
+						"figures": "^6.1.0",
+						"get-stream": "^9.0.0",
+						"human-signals": "^7.0.0",
+						"is-plain-obj": "^4.1.0",
+						"is-stream": "^4.0.1",
+						"npm-run-path": "^5.2.0",
+						"pretty-ms": "^9.0.0",
+						"signal-exit": "^4.1.0",
+						"strip-final-newline": "^4.0.0",
+						"yoctocolors": "^2.0.0"
+					},
+					"dependencies": {
+						"get-stream": {
+							"version": "9.0.1",
+							"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+							"integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+							"requires": {
+								"@sec-ant/readable-stream": "^0.4.1",
+								"is-stream": "^4.0.1"
+							}
+						}
+					}
+				},
+				"human-signals": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-7.0.0.tgz",
+					"integrity": "sha512-74kytxOUSvNbjrT9KisAbaTZ/eJwD/LrbM/kh5j0IhPuJzwuA19dWvniFGwBzN9rVjg+O/e+F310PjObDXS+9Q=="
+				},
+				"is-stream": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+					"integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="
+				},
+				"npm-run-path": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+					"integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+					"requires": {
+						"path-key": "^4.0.0"
+					}
+				},
+				"path-key": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+					"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="
+				},
+				"semver": {
+					"version": "7.6.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+					"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w=="
+				},
+				"signal-exit": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+					"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
+				},
+				"strip-final-newline": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+					"integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="
+				}
+			}
+		},
 		"semver": {
 			"version": "6.3.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
+		},
+		"semver-diff": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-4.0.0.tgz",
+			"integrity": "sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==",
+			"requires": {
+				"semver": "^7.3.5"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.6.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+					"integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w=="
+				}
+			}
+		},
+		"semver-regex": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
+			"integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw=="
 		},
 		"set-function-length": {
 			"version": "1.2.1",
@@ -11843,6 +20580,17 @@
 				"get-intrinsic": "^1.2.3",
 				"gopd": "^1.0.1",
 				"has-property-descriptors": "^1.0.1"
+			}
+		},
+		"set-function-name": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+			"integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+			"requires": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"functions-have-names": "^1.2.3",
+				"has-property-descriptors": "^1.0.2"
 			}
 		},
 		"shebang-command": {
@@ -11863,15 +20611,103 @@
 			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
 			"integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA=="
 		},
+		"side-channel": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+			"integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+			"requires": {
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.4",
+				"object-inspect": "^1.13.1"
+			}
+		},
 		"signal-exit": {
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
 		},
+		"signale": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/signale/-/signale-1.4.0.tgz",
+			"integrity": "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==",
+			"requires": {
+				"chalk": "^2.3.2",
+				"figures": "^2.0.0",
+				"pkg-conf": "^2.1.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+				},
+				"figures": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+					"integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
+					"requires": {
+						"escape-string-regexp": "^1.0.5"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
 		"sisteransi": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
 			"integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
+		},
+		"skin-tone": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+			"integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+			"requires": {
+				"unicode-emoji-modifier-base": "^1.0.0"
+			}
 		},
 		"slash": {
 			"version": "3.0.0",
@@ -11913,6 +20749,39 @@
 				"source-map": "^0.6.0"
 			}
 		},
+		"spawn-error-forwarder": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
+			"integrity": "sha512-gRjMgK5uFjbCvdibeGJuy3I5OYz6VLoVdsOJdA6wV0WlfQVLFueoqMxwwYD9RODdgb6oUIvlRlsyFSiQkMKu0g=="
+		},
+		"spdx-correct": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+			"integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+			"requires": {
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-exceptions": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+			"integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="
+		},
+		"spdx-expression-parse": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+			"requires": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"spdx-license-ids": {
+			"version": "3.0.17",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
+			"integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg=="
+		},
 		"split2": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -11929,6 +20798,23 @@
 			"integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
 			"requires": {
 				"escape-string-regexp": "^2.0.0"
+			}
+		},
+		"stream-combiner2": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+			"integrity": "sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==",
+			"requires": {
+				"duplexer2": "~0.1.0",
+				"readable-stream": "^2.0.2"
+			}
+		},
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"requires": {
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"string-argv": {
@@ -11955,6 +20841,37 @@
 				"strip-ansi": "^6.0.1"
 			}
 		},
+		"string.prototype.trim": {
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
+			"integrity": "sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==",
+			"requires": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.0",
+				"es-object-atoms": "^1.0.0"
+			}
+		},
+		"string.prototype.trimend": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
+			"integrity": "sha512-p73uL5VCHCO2BZZ6krwwQE3kCzM7NKmis8S//xEC6fQonchbum4eP6kR4DLEjQFO3Wnj3Fuo8NM0kOSjVdHjZQ==",
+			"requires": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
+			}
+		},
+		"string.prototype.trimstart": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+			"integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+			"requires": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-object-atoms": "^1.0.0"
+			}
+		},
 		"strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -11978,12 +20895,30 @@
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
 		},
+		"super-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.0.0.tgz",
+			"integrity": "sha512-CY8u7DtbvucKuquCmOFEKhr9Besln7n9uN8eFbwcoGYWXOMW07u2o8njWaiXt11ylS3qoGF55pILjRmPlbodyg==",
+			"requires": {
+				"function-timeout": "^1.0.1",
+				"time-span": "^5.1.0"
+			}
+		},
 		"supports-color": {
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"requires": {
 				"has-flag": "^4.0.0"
+			}
+		},
+		"supports-hyperlinks": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
+			"integrity": "sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==",
+			"requires": {
+				"has-flag": "^4.0.0",
+				"supports-color": "^7.0.0"
 			}
 		},
 		"supports-preserve-symlinks-flag": {
@@ -11995,6 +20930,34 @@
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+		},
+		"temp-dir": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+			"integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw=="
+		},
+		"tempy": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+			"integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+			"requires": {
+				"is-stream": "^3.0.0",
+				"temp-dir": "^3.0.0",
+				"type-fest": "^2.12.2",
+				"unique-string": "^3.0.0"
+			},
+			"dependencies": {
+				"is-stream": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+					"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="
+				},
+				"type-fest": {
+					"version": "2.19.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+					"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
+				}
+			}
 		},
 		"test-exclude": {
 			"version": "6.0.0",
@@ -12016,10 +20979,43 @@
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="
 		},
+		"thenify": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+			"requires": {
+				"any-promise": "^1.0.0"
+			}
+		},
+		"thenify-all": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+			"integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+			"requires": {
+				"thenify": ">= 3.1.0 < 4"
+			}
+		},
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+		},
+		"through2": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+			"requires": {
+				"readable-stream": "~2.3.6",
+				"xtend": "~4.0.1"
+			}
+		},
+		"time-span": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+			"integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+			"requires": {
+				"convert-hrtime": "^5.0.0"
+			}
 		},
 		"tmpl": {
 			"version": "1.0.5",
@@ -12058,6 +21054,16 @@
 				"punycode": "^2.1.1"
 			}
 		},
+		"traverse": {
+			"version": "0.6.9",
+			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.9.tgz",
+			"integrity": "sha512-7bBrcF+/LQzSgFmT0X5YclVqQxtv7TDJ1f8Wj7ibBu/U6BMLeOpUxuZjV7rMc44UtKxlnMFigdhFAIszSX1DMg==",
+			"requires": {
+				"gopd": "^1.0.1",
+				"typedarray.prototype.slice": "^1.0.3",
+				"which-typed-array": "^1.1.15"
+			}
+		},
 		"ts-api-utils": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
@@ -12082,20 +21088,116 @@
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
 			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
 		},
+		"typed-array-buffer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
+			"integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+			"requires": {
+				"call-bind": "^1.0.7",
+				"es-errors": "^1.3.0",
+				"is-typed-array": "^1.1.13"
+			}
+		},
+		"typed-array-byte-length": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
+			"integrity": "sha512-3iMJ9q0ao7WE9tWcaYKIptkNBuOIcZCCT0d4MRvuuH88fEoEH62IuQe0OtraD3ebQEoTRk8XCBoknUNc1Y67pw==",
+			"requires": {
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-proto": "^1.0.3",
+				"is-typed-array": "^1.1.13"
+			}
+		},
+		"typed-array-byte-offset": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
+			"integrity": "sha512-Ous0vodHa56FviZucS2E63zkgtgrACj7omjwd/8lTEMEPFFyjfixMZ1ZXenpgCFBBt4EC1J2XsyVS2gkG0eTFA==",
+			"requires": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-proto": "^1.0.3",
+				"is-typed-array": "^1.1.13"
+			}
+		},
+		"typed-array-length": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.6.tgz",
+			"integrity": "sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==",
+			"requires": {
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-proto": "^1.0.3",
+				"is-typed-array": "^1.1.13",
+				"possible-typed-array-names": "^1.0.0"
+			}
+		},
+		"typedarray.prototype.slice": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/typedarray.prototype.slice/-/typedarray.prototype.slice-1.0.3.tgz",
+			"integrity": "sha512-8WbVAQAUlENo1q3c3zZYuy5k9VzBQvp8AX9WOtbvyWlLM1v5JaSRmjubLjzHF4JFtptjH/5c/i95yaElvcjC0A==",
+			"requires": {
+				"call-bind": "^1.0.7",
+				"define-properties": "^1.2.1",
+				"es-abstract": "^1.23.0",
+				"es-errors": "^1.3.0",
+				"typed-array-buffer": "^1.0.2",
+				"typed-array-byte-offset": "^1.0.2"
+			}
+		},
 		"typescript": {
 			"version": "5.4.5",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
 			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ=="
+		},
+		"uglify-js": {
+			"version": "3.17.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+			"integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+			"optional": true
+		},
+		"unbox-primitive": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+			"integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"has-bigints": "^1.0.2",
+				"has-symbols": "^1.0.3",
+				"which-boxed-primitive": "^1.0.2"
+			}
 		},
 		"undici-types": {
 			"version": "5.26.5",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
 			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
 		},
+		"unicode-emoji-modifier-base": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+			"integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g=="
+		},
 		"unicorn-magic": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
 			"integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ=="
+		},
+		"unique-string": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+			"integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+			"requires": {
+				"crypto-random-string": "^4.0.0"
+			}
+		},
+		"universal-user-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
+			"integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q=="
 		},
 		"universalify": {
 			"version": "0.2.0",
@@ -12119,6 +21221,11 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"url-join": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
+			"integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA=="
+		},
 		"url-parse": {
 			"version": "1.5.10",
 			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -12128,6 +21235,11 @@
 				"requires-port": "^1.0.0"
 			}
 		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+		},
 		"v8-to-istanbul": {
 			"version": "9.2.0",
 			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
@@ -12136,6 +21248,15 @@
 				"@jridgewell/trace-mapping": "^0.3.12",
 				"@types/istanbul-lib-coverage": "^2.0.1",
 				"convert-source-map": "^2.0.0"
+			}
+		},
+		"validate-npm-package-license": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"requires": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
 			}
 		},
 		"w3c-xmlserializer": {
@@ -12189,6 +21310,35 @@
 				"isexe": "^2.0.0"
 			}
 		},
+		"which-boxed-primitive": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+			"requires": {
+				"is-bigint": "^1.0.1",
+				"is-boolean-object": "^1.1.0",
+				"is-number-object": "^1.0.4",
+				"is-string": "^1.0.5",
+				"is-symbol": "^1.0.3"
+			}
+		},
+		"which-typed-array": {
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
+			"integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+			"requires": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.7",
+				"for-each": "^0.3.3",
+				"gopd": "^1.0.1",
+				"has-tostringtag": "^1.0.2"
+			}
+		},
+		"wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
+		},
 		"wrap-ansi": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -12229,6 +21379,11 @@
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
 		},
+		"xtend": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+		},
 		"y18n": {
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -12267,6 +21422,11 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+		},
+		"yoctocolors": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.0.2.tgz",
+			"integrity": "sha512-Ct97huExsu7cWeEjmrXlofevF8CvzUglJ4iGUet5B8xn1oumtAZBpHU4GzYuoE6PVqcZ5hghtBrSlhwHuR1Jmw=="
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"// gha": "Use the `act` tool to test GitHub Actions workflows locally.",
 		"gha": "act",
 		"gha:build-check-test": "act --workflows .github/workflows/build-check-test.yaml",
+		"gha:release": "act --secret OP_SERVICE_ACCOUNT_TOKEN --workflows .github/workflows/release.yaml",
 		"// githooks": "Refer to the files in the ./.githooks/ folder for documentation on these commands.",
 		"githooks:commit-msg": "commitlint --config ./lib/commitlint.config.js --edit",
 		"githooks:pre-commit": "npm run build && lint-staged --config ./lib/lint-staged.config.js --relative",
@@ -68,6 +69,7 @@
 		"lint-staged": "15.2.2",
 		"npm-run-all2": "6.1.2",
 		"prettier": "3.2.5",
+		"semantic-release": "23.1.1",
 		"typescript": "5.4.5"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
 		"@commitlint/config-conventional": "19.2.2",
 		"@prettier/plugin-pug": "3.0.0",
 		"@prettier/plugin-xml": "3.4.1",
+		"@semantic-release/changelog": "6.0.3",
+		"@semantic-release/git": "10.0.1",
 		"@swc/core": "1.5.7",
 		"@swc/jest": "0.2.36",
 		"@tsconfig/strictest": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "dr-devdeps",
+	"name": "@dustin-ruetz/web-dev-deps",
 	"version": "0.18.0",
 	"description": "",
 	"main": "index.js",
@@ -46,7 +46,7 @@
 		"npm": ">=10"
 	},
 	"repository": {
-		"url": "git@github.com:dustin-ruetz/dr-devdeps.git"
+		"url": "git@github.com:dustin-ruetz/web-dev-deps.git"
 	},
 	"type": "module",
 	"dependencies": {

--- a/src/jest.config.test.ts
+++ b/src/jest.config.test.ts
@@ -16,7 +16,7 @@ const mockGetRepoMetadata = getRepoMetadata as jest.MockedFunction<
  */
 const actualGetRepoMetadata = () =>
 	({
-		dependencyPartialPath: "node_modules/dr-devdeps",
+		dependencyPartialPath: "node_modules/@dustin-ruetz/web-dev-deps",
 	}) as const;
 
 afterEach(() => {
@@ -28,9 +28,9 @@ describe("it exports a configuration object and the most important config option
 		const hasFrontendDependencies = false;
 		dependsOnMock.mockResolvedValue(hasFrontendDependencies);
 		mockGetRepoMetadata.mockReturnValue({
-			absoluteRootDir: "/Users/username/repos/dr-devdeps",
+			absoluteRootDir: "/Users/username/repos/web-dev-deps",
 			dependencyPartialPath: actualGetRepoMetadata().dependencyPartialPath,
-			isDevDepsRepo: true,
+			isWebDevDepsRepo: true,
 		});
 
 		const jestConfig = await makeJestConfig();
@@ -42,18 +42,18 @@ describe("it exports a configuration object and the most important config option
 		expect(jestConfig.verbose).toBe(true);
 	});
 
-	test("when testing this dr-devdeps repo (which *does not* have frontend dependencies)", async () => {
+	test("when testing this web-dev-deps repo (which *does not* have frontend dependencies)", async () => {
 		const hasFrontendDependencies = false;
 		dependsOnMock.mockResolvedValue(hasFrontendDependencies);
 		mockGetRepoMetadata.mockReturnValue({
-			absoluteRootDir: "/Users/username/repos/dr-devdeps",
+			absoluteRootDir: "/Users/username/repos/web-dev-deps",
 			dependencyPartialPath: actualGetRepoMetadata().dependencyPartialPath,
-			isDevDepsRepo: true,
+			isWebDevDepsRepo: true,
 		});
 
 		const jestConfig = await makeJestConfig();
 
-		expect(jestConfig.rootDir).toEqual("/Users/username/repos/dr-devdeps");
+		expect(jestConfig.rootDir).toEqual("/Users/username/repos/web-dev-deps");
 		expect(jestConfig.testEnvironment).toEqual("node");
 		// Sample the transform config object to verify that the paths to the transformer files are correct.
 		expect(jestConfig.transform?.[".svg"]).toEqual(
@@ -61,14 +61,14 @@ describe("it exports a configuration object and the most important config option
 		);
 	});
 
-	test("when testing a repo that has installed the dr-devdeps package (repo *does* have frontend dependencies)", async () => {
+	test("when testing a repo that has installed the web-dev-deps package (repo *does* have frontend dependencies)", async () => {
 		const hasFrontendDependencies = true;
 		dependsOnMock.mockResolvedValue(hasFrontendDependencies);
 		dependsOnMock.mockResolvedValue(true);
 		mockGetRepoMetadata.mockReturnValue({
 			absoluteRootDir: "/Users/username/repos/consuming-repo",
 			dependencyPartialPath: actualGetRepoMetadata().dependencyPartialPath,
-			isDevDepsRepo: false,
+			isWebDevDepsRepo: false,
 		});
 
 		const jestConfig = await makeJestConfig();
@@ -77,7 +77,7 @@ describe("it exports a configuration object and the most important config option
 		expect(jestConfig.testEnvironment).toEqual("jsdom");
 		// Sample the transform config object to verify that the paths to the transformer files are correct.
 		expect(jestConfig.transform?.[".svg"]).toEqual(
-			"<rootDir>/node_modules/dr-devdeps/lib/jest-transformers/svgFile.js",
+			"<rootDir>/node_modules/@dustin-ruetz/web-dev-deps/lib/jest-transformers/svgFile.js",
 		);
 	});
 });

--- a/src/jest.config.ts
+++ b/src/jest.config.ts
@@ -9,7 +9,7 @@ export const makeJestConfig = async (): Promise<Config> => {
 		? "jsdom"
 		: "node";
 
-	const {absoluteRootDir, dependencyPartialPath, isDevDepsRepo} =
+	const {absoluteRootDir, dependencyPartialPath, isWebDevDepsRepo} =
 		getRepoMetadata();
 
 	/** Binary file extensions 1) to ignore in test coverage, and 2) to transform the imported values to filenames. */
@@ -29,10 +29,10 @@ export const makeJestConfig = async (): Promise<Config> => {
 	] as const;
 
 	/**
-	 * Folder/file patterns to ignore for this dr-devdeps repo because
+	 * Folder/file patterns to ignore for this `web-dev-deps` repo because
 	 * the unit tests are using `vi` instead of `jest` for mocking.
 	 */
-	// const devDepsIgnorePatterns = !isDevDepsRepo
+	// const webDevDepsIgnorePatterns = !isWebDevDepsRepo
 	// 	? ([
 	// 			"<rootDir>/scripts/",
 	// 			"<rootDir>/src/utils/",
@@ -42,10 +42,10 @@ export const makeJestConfig = async (): Promise<Config> => {
 	// 	: ([] as const);
 
 	/** The base path to the files/packages used as Jest transformers. */
-	const transformerBasePath = isDevDepsRepo
-		? // If running tests on this `dr-devdeps` repo, set the path relative to the Jest <rootDir>.
+	const transformerBasePath = isWebDevDepsRepo
+		? // If running tests on this `web-dev-deps` repo, set the path relative to the Jest <rootDir>.
 			("<rootDir>" as const)
-		: // If running tests on a `consuming-repo`, set the path relative to its `dr-devdeps` dependency.
+		: // If running tests on a `consuming-repo`, set the path relative to its `web-dev-deps` dependency.
 			(`<rootDir>/${dependencyPartialPath}` as const);
 
 	// Note: The `cjs` and `cts` file extensions are included in the Jest config because this repo has some tools
@@ -61,7 +61,7 @@ export const makeJestConfig = async (): Promise<Config> => {
 		coveragePathIgnorePatterns: [
 			...ignorePatterns,
 			...binaryFileExtensions.list,
-			// ...devDepsIgnorePatterns,
+			// ...webDevDepsIgnorePatterns,
 		],
 		// Set coverage provider as v8 to align with the Vitest default.
 		coverageProvider: "v8",
@@ -92,9 +92,10 @@ export const makeJestConfig = async (): Promise<Config> => {
 			// https://github.com/kulshekhar/ts-jest/issues/1057#issuecomment-1482644543:
 			"^(\\.\\.?\\/.+)\\.(cjs|js|jsx)": "$1",
 		},
-		// Note that while `rootDir` is set to an absolute path here, Jest also knows how to interpret relative paths. For example,
-		// a consuming repo depending on dr-devdeps could use "../../../" as the path to traverse three levels upwards to hit root.
-		// (i.e. starting from lib/, move upwards three times: dr-devdeps/ ^ node_modules/ ^ consuming-repo/)
+		// Note that while `rootDir` is set to an absolute path here, Jest also knows how to interpret relative paths.
+		// For example, a consuming repo depending on `web-dev-deps` could use "../../../../" as the path to traverse
+		// four levels upwards to reach the root. (i.e. starting from lib/, move upwards three times:
+		// web-dev-deps/ ^ @dustin-ruetz/ ^ node_modules/ ^ consuming-repo/)
 		// Excerpt from https://jestjs.io/docs/configuration#rootdir-string:
 		// > The root directory that Jest should scan for tests and modules within.
 		// > Oftentimes, you'll want to set this to `"src"` or `"lib"`, corresponding to where in your repository the code is stored.
@@ -105,7 +106,7 @@ export const makeJestConfig = async (): Promise<Config> => {
 		testEnvironment,
 		testPathIgnorePatterns: [
 			...ignorePatterns,
-			// ...devDepsIgnorePatterns
+			// ...webDevDepsIgnorePatterns
 		],
 		// Excerpt from https://jestjs.io/docs/configuration#transform-objectstring-pathtotransformer--pathtotransformer-object:
 		// > A map from regular expressions to paths to transformers.

--- a/src/semantic-release.config.cts
+++ b/src/semantic-release.config.cts
@@ -1,0 +1,9 @@
+/** https://semantic-release.gitbook.io/semantic-release/usage/configuration */
+const semanticReleaseConfig = {
+	// TODO: This `branches` array is for testing purposes; remove before merging this PR.
+	branches: ["configure-semantic-release"],
+	// TODO: The `dryRun` boolean is for testing purposes; remove before merging this PR.
+	dryRun: true,
+};
+
+module.exports = semanticReleaseConfig;

--- a/src/semantic-release.config.cts
+++ b/src/semantic-release.config.cts
@@ -4,6 +4,30 @@ const semanticReleaseConfig = {
 	branches: ["configure-semantic-release"],
 	// TODO: The `dryRun` boolean is for testing purposes; remove before merging this PR.
 	dryRun: true,
+	plugins: [
+		"@semantic-release/commit-analyzer",
+		"@semantic-release/release-notes-generator",
+		// https://github.com/semantic-release/changelog
+		[
+			"@semantic-release/changelog",
+			{
+				changelogFile: "CHANGELOG.md",
+				changelogTitle: "CHANGELOG",
+			},
+		],
+		"@semantic-release/npm",
+		// https://github.com/semantic-release/git
+		[
+			"@semantic-release/git",
+			{
+				assets: ["CHANGELOG.md", "package-lock.json", "package.json"],
+				message:
+					// eslint-disable-next-line no-template-curly-in-string
+					"chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
+			},
+		],
+		"@semantic-release/github",
+	],
 };
 
 module.exports = semanticReleaseConfig;

--- a/src/semantic-release.config.cts
+++ b/src/semantic-release.config.cts
@@ -1,9 +1,7 @@
 /** https://semantic-release.gitbook.io/semantic-release/usage/configuration */
 const semanticReleaseConfig = {
 	// TODO: This `branches` array is for testing purposes; remove before merging this PR.
-	branches: ["configure-semantic-release"],
-	// TODO: The `dryRun` boolean is for testing purposes; remove before merging this PR.
-	dryRun: true,
+	// branches: ["configure-semantic-release"],
 	plugins: [
 		"@semantic-release/commit-analyzer",
 		"@semantic-release/release-notes-generator",

--- a/src/semantic-release.config.test.ts
+++ b/src/semantic-release.config.test.ts
@@ -1,0 +1,8 @@
+import type {Options} from "semantic-release";
+import semanticReleaseCfg from "./semantic-release.config.cjs";
+
+const semanticReleaseConfig: Options = semanticReleaseCfg;
+
+test("it exports a configuration object and the most important config options are correct", () => {
+	expect(typeof semanticReleaseConfig).toEqual("object");
+});

--- a/src/utils/dependsOn.test.ts
+++ b/src/utils/dependsOn.test.ts
@@ -11,9 +11,9 @@ const mockReadFile = readFile as jest.MockedFunction<typeof readFile>;
 
 jest.mock("./getRepoMetadata.js", () => ({
 	getRepoMetadata: jest.fn(() => ({
-		absoluteRootDir: "/Users/username/repos/dr-devdeps",
-		dependencyPartialPath: "node_modules/dr-devdeps",
-		isDevDepsRepo: true,
+		absoluteRootDir: "/Users/username/repos/web-dev-deps",
+		dependencyPartialPath: "node_modules/@dustin-ruetz/web-dev-deps",
+		isWebDevDepsRepo: true,
 	})),
 }));
 
@@ -57,7 +57,7 @@ test("returns `false` if the repo does not depend on the package", async () => {
 
 	expect(getRepoMetadata).toHaveBeenCalledTimes(1);
 	expect(mockReadFile).toHaveBeenCalledWith(
-		"/Users/username/repos/dr-devdeps/package.json",
+		"/Users/username/repos/web-dev-deps/package.json",
 		{encoding: "utf-8"},
 	);
 	expect(dependsOnDep0).toBe(false);

--- a/src/utils/getRepoMetadata.test.ts
+++ b/src/utils/getRepoMetadata.test.ts
@@ -14,25 +14,26 @@ const mockFileURLToPath = fileURLToPath as jest.MockedFunction<
 const absolutePaths = {
 	// Start by defining the static partials that comprise the absolute paths.
 	base: "/Users/username/repos",
-	name: "dr-devdeps",
+	namespace: "@dustin-ruetz",
+	name: "web-dev-deps",
 	partial: "utils/getRepoMetadata",
 	// Combine the static partials in the return values of the methods.
 	/**
-	 * - Simulates path of dr-devdeps being installed as a dependency running from a `node_modules/` folder.
-	 * - Rationale: Test the value of `getRepoMetadata().absoluteRootDir` when used by a repository that depends on the `dr-deveps` package.
+	 * - Simulates path of web-dev-deps being installed as a dependency running from a `node_modules/` folder.
+	 * - Rationale: Test the value of `getRepoMetadata().absoluteRootDir` when used by a repository that depends on the `web-dev-deps` package.
 	 */
 	asDependency() {
-		return `${this.base}/consuming-repo/node_modules/${this.name}/lib/${this.partial}.js`;
+		return `${this.base}/consuming-repo/node_modules/${this.namespace}/${this.name}/lib/${this.partial}.js`;
 	},
 	/**
-	 * - Simulates path of this dr-devdeps repo running a compiled `.js` file.
+	 * - Simulates path of this web-dev-deps repo running a compiled `.js` file.
 	 * - Rationale: Test the value of `getRepoMetadata().absoluteRootDir` when used in a `lib/*.js` file.
 	 */
 	asLibraryJavaScriptFile() {
 		return `${this.base}/${this.name}/lib/${this.partial}.js`;
 	},
 	/**
-	 * - Simulates path of this dr-devdeps repo running a source `.ts` file.
+	 * - Simulates path of this web-dev-deps repo running a source `.ts` file.
 	 * - Rationale: Test the value of `getRepoMetadata().absoluteRootDir` during a test run in a `src/*.ts` test file.
 	 */
 	asSourceTypeScriptFile() {
@@ -54,31 +55,33 @@ describe("it determines the correct absolute root directory", () => {
 		const absolutePath = absolutePaths.asDependency();
 		mockFileURLToPath.mockReturnValue(absolutePath);
 
-		const {absoluteRootDir, dependencyPartialPath, isDevDepsRepo} =
+		const {absoluteRootDir, dependencyPartialPath, isWebDevDepsRepo} =
 			getRepoMetadata();
 
 		expect(absoluteRootDir).toEqual("/Users/username/repos/consuming-repo");
-		expect(dependencyPartialPath).toEqual("node_modules/dr-devdeps");
-		expect(isDevDepsRepo).toBe(false);
+		expect(dependencyPartialPath).toEqual(
+			"node_modules/@dustin-ruetz/web-dev-deps",
+		);
+		expect(isWebDevDepsRepo).toBe(false);
 	});
 
 	test("when run as a JavaScript file inside the lib/ folder", () => {
 		const absolutePath = absolutePaths.asLibraryJavaScriptFile();
 		mockFileURLToPath.mockReturnValue(absolutePath);
 
-		const {absoluteRootDir, isDevDepsRepo} = getRepoMetadata();
+		const {absoluteRootDir, isWebDevDepsRepo} = getRepoMetadata();
 
-		expect(absoluteRootDir).toEqual("/Users/username/repos/dr-devdeps");
-		expect(isDevDepsRepo).toBe(true);
+		expect(absoluteRootDir).toEqual("/Users/username/repos/web-dev-deps");
+		expect(isWebDevDepsRepo).toBe(true);
 	});
 
 	test("when run as a TypeScript file inside the src/ folder", () => {
 		const absolutePath = absolutePaths.asSourceTypeScriptFile();
 		mockFileURLToPath.mockReturnValue(absolutePath);
 
-		const {absoluteRootDir, isDevDepsRepo} = getRepoMetadata();
+		const {absoluteRootDir, isWebDevDepsRepo} = getRepoMetadata();
 
-		expect(absoluteRootDir).toEqual("/Users/username/repos/dr-devdeps");
-		expect(isDevDepsRepo).toBe(true);
+		expect(absoluteRootDir).toEqual("/Users/username/repos/web-dev-deps");
+		expect(isWebDevDepsRepo).toBe(true);
 	});
 });

--- a/src/utils/getRepoMetadata.ts
+++ b/src/utils/getRepoMetadata.ts
@@ -11,8 +11,8 @@ import {ValidationError} from "./ValidationError.js";
  *
  * This function uses the known location of the `utils/getRepoMetadata` file within the repo's structure and uses it as an anchor point
  * to determine the absolute root directory of the repo where it's being called from. It can return the absolute path of either:
- * 1. The consuming repository where the `dr-devdeps` package is installed as a dependency; or
- * 2. This `dr-devdeps` repo itself.
+ * 1. The consuming repository where the `web-dev-deps` package is installed as a dependency; or
+ * 2. This `web-dev-deps` repo itself.
  *
  * **Important:** Note that the `absoluteRootDir` path is intentionally returned _without_ a trailing slash.
  */
@@ -37,8 +37,8 @@ export const getRepoMetadata = () => {
 			},
 		);
 	}
-	/** `dependencyPartialPath` is known and stable; it's the location where the `dr-devdeps` package is installed as a dependency. */
-	const dependencyPartialPath = "node_modules/dr-devdeps";
+	/** `dependencyPartialPath` is known and stable; it's the location where the `web-dev-deps` package is installed as a dependency. */
+	const dependencyPartialPath = "node_modules/@dustin-ruetz/web-dev-deps";
 	/**
 	 * `relativePath` is defined as a regular expression so that it covers two types of paths:
 	 * 1. A compiled JavaScript file in the lib/ directory; and
@@ -49,7 +49,7 @@ export const getRepoMetadata = () => {
 	const dependencyRelativePath = new RegExp(
 		`${dependencyPartialPath}/${relativePath.source}`,
 	);
-	let absoluteRootDir;
+	let absoluteRootDir = "";
 	if (absolutePath.includes(dependencyPartialPath)) {
 		absoluteRootDir = absolutePath.replace(dependencyRelativePath, "");
 	} else {
@@ -58,7 +58,7 @@ export const getRepoMetadata = () => {
 	// Remove the last character in the string, i.e. the path's trailing slash.
 	absoluteRootDir = absoluteRootDir.slice(0, -1);
 
-	const isDevDepsRepo = absoluteRootDir.endsWith("/dr-devdeps");
+	const isWebDevDepsRepo = absoluteRootDir.endsWith("/web-dev-deps");
 
-	return {absoluteRootDir, dependencyPartialPath, isDevDepsRepo} as const;
+	return {absoluteRootDir, dependencyPartialPath, isWebDevDepsRepo} as const;
 };


### PR DESCRIPTION
- This PR serves as the initial attempt at using the `semantic-release` package to automatically release version 1 of the package.
  - In the `semantic-release` configuration file the non-standard `@semantic-release/changelog` and `@semantic-release/git` plugins have been implemented in order to commit a `CHANGELOG.md` file and the package's version number to the `package.json` and `package-lock.json` files as part of the release.
- It also renames the repository (from a top-level `dr-scripts` package to the user-scoped/namespaced `@dustin-ruetz/web-dev-deps` package); these changes ensure that it's correctly named prior to publishing to NPM.