### PR TITLE
fix(package.json): set 'publishConfig.access' to 'public'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,0 @@
-CHANGELOG
-
-## [1.0.3](https://github.com/dustin-ruetz/web-dev-deps/compare/v1.0.2...v1.0.3) (2024-05-22)
-
-
-### Bug Fixes
-
-* **.github/workflows/build-check-test:** don't run job on push to 'main' branch ([#29](https://github.com/dustin-ruetz/web-dev-deps/issues/29)) ([786530a](https://github.com/dustin-ruetz/web-dev-deps/commit/786530a8a752dd40059da08a1a215a78cdb6004f))

--- a/__tests__/packageJSON.test.ts
+++ b/__tests__/packageJSON.test.ts
@@ -3,6 +3,9 @@ import packageJSON from "../package.json";
 test("the most important configuration options are correct", () => {
 	expect(packageJSON.name).toEqual("@dustin-ruetz/web-dev-deps");
 	expect(packageJSON.author).toEqual("Dustin Ruetz");
+	// Set `publishConfig.access` to `public` to prevent the following NPM error:
+	// > npm error 402 Payment Required - You must sign up for private packages.
+	expect(packageJSON.publishConfig.access).toEqual("public");
 	expect(packageJSON.type).toEqual("module");
 });
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
 		"node": ">=18",
 		"npm": ">=10"
 	},
+	"publishConfig": {
+		"access": "public"
+	},
 	"repository": {
 		"url": "git@github.com:dustin-ruetz/web-dev-deps.git"
 	},


### PR DESCRIPTION
This PR sets `publishConfig.access` to `public` in the package.json file to prevent the following NPM error that occurs when `semantic-release` attempts to publish to the package registry:

> npm error 402 Payment Required - You must sign up for private packages.