### PR TITLE
feat: configure Stylelint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,12 @@
 				"jest-environment-jsdom": "29.7.0",
 				"lint-staged": "15.2.5",
 				"npm-run-all2": "6.2.0",
+				"postcss-scss": "4.0.9",
+				"postcss-styled-syntax": "0.6.4",
 				"prettier": "3.3.1",
 				"semantic-release": "23.1.1",
+				"stylelint": "16.6.1",
+				"stylelint-config-standard-scss": "13.1.0",
 				"typescript": "5.4.5"
 			},
 			"devDependencies": {
@@ -1400,6 +1404,97 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.6.3.tgz",
+			"integrity": "sha512-xI/tL2zxzEbESvnSxwFgwvy5HS00oCXxL4MLs6HUiDcYfwowsoQaABKxUElp1ARITrINzBnsECOc1q0eg2GOrA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"engines": {
+				"node": "^14 || ^16 || >=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^2.3.1"
+			}
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.3.1.tgz",
+			"integrity": "sha512-iMNHTyxLbBlWIfGtabT157LH9DUx9X8+Y3oymFEuMj8HNc+rpE3dPFGFgHjpKfjeFDjLjYIAIhXPGvS2lKxL9g==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"engines": {
+				"node": "^14 || ^16 || >=18"
+			}
+		},
+		"node_modules/@csstools/media-query-list-parser": {
+			"version": "2.1.11",
+			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.11.tgz",
+			"integrity": "sha512-uox5MVhvNHqitPP+SynrB1o8oPxPMt2JLgp5ghJOWf54WGQ5OKu47efne49r1SWqs3wRP8xSWjnO9MBKxhB1dA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"engines": {
+				"node": "^14 || ^16 || >=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^2.6.3",
+				"@csstools/css-tokenizer": "^2.3.1"
+			}
+		},
+		"node_modules/@csstools/selector-specificity": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.1.1.tgz",
+			"integrity": "sha512-a7cxGcJ2wIlMFLlh8z2ONm+715QkPHiyJcxwQlKOz/03GPw1COpfhcmC9wm4xlZfp//jWHNNMwzjtqHXVWU9KA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"engines": {
+				"node": "^14 || ^16 || >=18"
+			},
+			"peerDependencies": {
+				"postcss-selector-parser": "^6.0.13"
+			}
+		},
+		"node_modules/@dual-bundle/import-meta-resolve": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
+			"integrity": "sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg==",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
@@ -3444,6 +3539,14 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/astral-regex": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3956,6 +4059,11 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
+		"node_modules/colord": {
+			"version": "2.9.3",
+			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+			"integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw=="
+		},
 		"node_modules/colorette": {
 			"version": "2.0.20",
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
@@ -4219,6 +4327,37 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/css-functions-list": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.2.tgz",
+			"integrity": "sha512-c+N0v6wbKVxTu5gOBBFkr9BEdBWaqqjQeiJ8QvSRIJOf+UxlJh930m8e6/WNeODIK0mYLFkoONrnj16i2EcvfQ==",
+			"engines": {
+				"node": ">=12 || >=16"
+			}
+		},
+		"node_modules/css-tree": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+			"integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+			"dependencies": {
+				"mdn-data": "2.0.30",
+				"source-map-js": "^1.0.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
+		"node_modules/cssesc": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+			"bin": {
+				"cssesc": "bin/cssesc"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/cssom": {
@@ -5153,6 +5292,14 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
 		},
+		"node_modules/fastest-levenshtein": {
+			"version": "1.0.16",
+			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+			"integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+			"engines": {
+				"node": ">= 4.9.1"
+			}
+		},
 		"node_modules/fastq": {
 			"version": "1.16.0",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
@@ -5257,9 +5404,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.2.9",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
-			"integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
 		},
 		"node_modules/for-each": {
 			"version": "0.3.3",
@@ -5535,6 +5682,46 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/global-modules": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+			"integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+			"dependencies": {
+				"global-prefix": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/global-prefix": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+			"integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+			"dependencies": {
+				"ini": "^1.3.5",
+				"kind-of": "^6.0.2",
+				"which": "^1.3.1"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/global-prefix/node_modules/ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+		},
+		"node_modules/global-prefix/node_modules/which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"which": "bin/which"
+			}
+		},
 		"node_modules/globals": {
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -5576,6 +5763,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/globjoin": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+			"integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg=="
 		},
 		"node_modules/gopd": {
 			"version": "1.0.1",
@@ -5756,6 +5948,17 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
 			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
+		},
+		"node_modules/html-tags": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
+			"integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/http-proxy-agent": {
 			"version": "5.0.0",
@@ -6175,6 +6378,14 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-potential-custom-element-name": {
@@ -7150,6 +7361,14 @@
 				"json-buffer": "3.0.1"
 			}
 		},
+		"node_modules/kind-of": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/kleur": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -7157,6 +7376,11 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/known-css-properties": {
+			"version": "0.31.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.31.0.tgz",
+			"integrity": "sha512-sBPIUGTNF0czz0mwGGUoKKJC8Q7On1GPbCSFPfyEsfHb2DyBG0Y4QtV+EVWpINSaiGKZblDNuF5AezxSgOhesQ=="
 		},
 		"node_modules/leven": {
 			"version": "3.1.0",
@@ -7549,6 +7773,11 @@
 			"resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
 			"integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="
 		},
+		"node_modules/lodash.truncate": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+			"integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
+		},
 		"node_modules/lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -7807,6 +8036,20 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
+		"node_modules/mathml-tag-names": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
+			"integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/mdn-data": {
+			"version": "2.0.30",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
+		},
 		"node_modules/memorystream": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
@@ -7924,6 +8167,23 @@
 				"any-promise": "^1.0.0",
 				"object-assign": "^4.0.1",
 				"thenify-all": "^1.0.0"
+			}
+		},
+		"node_modules/nanoid": {
+			"version": "3.3.7",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+			"integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
 		"node_modules/natural-compare": {
@@ -10773,9 +11033,9 @@
 			}
 		},
 		"node_modules/picocolors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+			"integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
@@ -10906,6 +11166,124 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/postcss": {
+			"version": "8.4.38",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+			"integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"dependencies": {
+				"nanoid": "^3.3.7",
+				"picocolors": "^1.0.0",
+				"source-map-js": "^1.2.0"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/postcss-media-query-parser": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+			"integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig=="
+		},
+		"node_modules/postcss-resolve-nested-selector": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
+			"integrity": "sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw=="
+		},
+		"node_modules/postcss-safe-parser": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.0.tgz",
+			"integrity": "sha512-ovehqRNVCpuFzbXoTb4qLtyzK3xn3t/CUBxOs8LsnQjQrShaB4lKiHoVqY8ANaC0hBMHq5QVWk77rwGklFUDrg==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"engines": {
+				"node": ">=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-scss": {
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
+			"integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss-scss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"engines": {
+				"node": ">=12.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.29"
+			}
+		},
+		"node_modules/postcss-selector-parser": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.0.tgz",
+			"integrity": "sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ==",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/postcss-styled-syntax": {
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/postcss-styled-syntax/-/postcss-styled-syntax-0.6.4.tgz",
+			"integrity": "sha512-uWiLn+9rKgIghUYmTHvXMR6MnyPULMe9Gv3bV537Fg4FH6CA6cn21WMjKss2Qb98LUhT847tKfnRGG3FhSOgUQ==",
+			"dependencies": {
+				"typescript": "^5.3.3"
+			},
+			"engines": {
+				"node": ">=14.17"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.21"
+			}
+		},
+		"node_modules/postcss-value-parser": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
 		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
@@ -11893,6 +12271,14 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/source-map-js": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+			"integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/source-map-support": {
 			"version": "0.5.13",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
@@ -12093,6 +12479,241 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/stylelint": {
+			"version": "16.6.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.6.1.tgz",
+			"integrity": "sha512-yNgz2PqWLkhH2hw6X9AweV9YvoafbAD5ZsFdKN9BvSDVwGvPh+AUIrn7lYwy1S7IHmtFin75LLfX1m0D2tHu8Q==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/stylelint"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/stylelint"
+				}
+			],
+			"dependencies": {
+				"@csstools/css-parser-algorithms": "^2.6.3",
+				"@csstools/css-tokenizer": "^2.3.1",
+				"@csstools/media-query-list-parser": "^2.1.11",
+				"@csstools/selector-specificity": "^3.1.1",
+				"@dual-bundle/import-meta-resolve": "^4.1.0",
+				"balanced-match": "^2.0.0",
+				"colord": "^2.9.3",
+				"cosmiconfig": "^9.0.0",
+				"css-functions-list": "^3.2.2",
+				"css-tree": "^2.3.1",
+				"debug": "^4.3.4",
+				"fast-glob": "^3.3.2",
+				"fastest-levenshtein": "^1.0.16",
+				"file-entry-cache": "^9.0.0",
+				"global-modules": "^2.0.0",
+				"globby": "^11.1.0",
+				"globjoin": "^0.1.4",
+				"html-tags": "^3.3.1",
+				"ignore": "^5.3.1",
+				"imurmurhash": "^0.1.4",
+				"is-plain-object": "^5.0.0",
+				"known-css-properties": "^0.31.0",
+				"mathml-tag-names": "^2.1.3",
+				"meow": "^13.2.0",
+				"micromatch": "^4.0.7",
+				"normalize-path": "^3.0.0",
+				"picocolors": "^1.0.1",
+				"postcss": "^8.4.38",
+				"postcss-resolve-nested-selector": "^0.1.1",
+				"postcss-safe-parser": "^7.0.0",
+				"postcss-selector-parser": "^6.1.0",
+				"postcss-value-parser": "^4.2.0",
+				"resolve-from": "^5.0.0",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^7.1.0",
+				"supports-hyperlinks": "^3.0.0",
+				"svg-tags": "^1.0.0",
+				"table": "^6.8.2",
+				"write-file-atomic": "^5.0.1"
+			},
+			"bin": {
+				"stylelint": "bin/stylelint.mjs"
+			},
+			"engines": {
+				"node": ">=18.12.0"
+			}
+		},
+		"node_modules/stylelint-config-recommended": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.0.tgz",
+			"integrity": "sha512-jSkx290CglS8StmrLp2TxAppIajzIBZKYm3IxT89Kg6fGlxbPiTiyH9PS5YUuVAFwaJLl1ikiXX0QWjI0jmgZQ==",
+			"engines": {
+				"node": ">=18.12.0"
+			},
+			"peerDependencies": {
+				"stylelint": "^16.0.0"
+			}
+		},
+		"node_modules/stylelint-config-recommended-scss": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-14.0.0.tgz",
+			"integrity": "sha512-HDvpoOAQ1RpF+sPbDOT2Q2/YrBDEJDnUymmVmZ7mMCeNiFSdhRdyGEimBkz06wsN+HaFwUh249gDR+I9JR7Onw==",
+			"dependencies": {
+				"postcss-scss": "^4.0.9",
+				"stylelint-config-recommended": "^14.0.0",
+				"stylelint-scss": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=18.12.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.3.3",
+				"stylelint": "^16.0.2"
+			},
+			"peerDependenciesMeta": {
+				"postcss": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/stylelint-config-standard": {
+			"version": "36.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-36.0.0.tgz",
+			"integrity": "sha512-3Kjyq4d62bYFp/Aq8PMKDwlgUyPU4nacXsjDLWJdNPRUgpuxALu1KnlAHIj36cdtxViVhXexZij65yM0uNIHug==",
+			"dependencies": {
+				"stylelint-config-recommended": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18.12.0"
+			},
+			"peerDependencies": {
+				"stylelint": "^16.1.0"
+			}
+		},
+		"node_modules/stylelint-config-standard-scss": {
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-13.1.0.tgz",
+			"integrity": "sha512-Eo5w7/XvwGHWkeGLtdm2FZLOMYoZl1omP2/jgFCXyl2x5yNz7/8vv4Tj6slHvMSSUNTaGoam/GAZ0ZhukvalfA==",
+			"dependencies": {
+				"stylelint-config-recommended-scss": "^14.0.0",
+				"stylelint-config-standard": "^36.0.0"
+			},
+			"engines": {
+				"node": ">=18.12.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.3.3",
+				"stylelint": "^16.3.1"
+			},
+			"peerDependenciesMeta": {
+				"postcss": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/stylelint-scss": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.3.1.tgz",
+			"integrity": "sha512-w/czBoWUZxJNk5fBRPODcXSN4qcPv3WHjTSSpFovVY+TE3MZTMR0yRlbmaDYrm8tTWHvpwQAuEBZ0lk2wwkboQ==",
+			"dependencies": {
+				"known-css-properties": "^0.31.0",
+				"postcss-media-query-parser": "^0.2.3",
+				"postcss-resolve-nested-selector": "^0.1.1",
+				"postcss-selector-parser": "^6.1.0",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"engines": {
+				"node": ">=18.12.0"
+			},
+			"peerDependencies": {
+				"stylelint": "^16.0.2"
+			}
+		},
+		"node_modules/stylelint/node_modules/ansi-regex": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/stylelint/node_modules/balanced-match": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
+			"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA=="
+		},
+		"node_modules/stylelint/node_modules/file-entry-cache": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-9.0.0.tgz",
+			"integrity": "sha512-6MgEugi8p2tiUhqO7GnPsmbCCzj0YRCwwaTbpGRyKZesjRSzkqkAE9fPp7V2yMs5hwfgbQLgdvSSkGNg1s5Uvw==",
+			"dependencies": {
+				"flat-cache": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/stylelint/node_modules/flat-cache": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-5.0.0.tgz",
+			"integrity": "sha512-JrqFmyUl2PnPi1OvLyTVHnQvwQ0S+e6lGSwu8OkAZlSaNIZciTY2H/cOOROxsBA1m/LZNHDsqAgDZt6akWcjsQ==",
+			"dependencies": {
+				"flatted": "^3.3.1",
+				"keyv": "^4.5.4"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/stylelint/node_modules/meow": {
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+			"integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/stylelint/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/stylelint/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/stylelint/node_modules/write-file-atomic": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+			"dependencies": {
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
 		"node_modules/super-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.0.0.tgz",
@@ -12142,10 +12763,66 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/svg-tags": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+			"integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA=="
+		},
 		"node_modules/symbol-tree": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+		},
+		"node_modules/table": {
+			"version": "6.8.2",
+			"resolved": "https://registry.npmjs.org/table/-/table-6.8.2.tgz",
+			"integrity": "sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==",
+			"dependencies": {
+				"ajv": "^8.0.1",
+				"lodash.truncate": "^4.4.2",
+				"slice-ansi": "^4.0.0",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/table/node_modules/ajv": {
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
+			"integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.4.1"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/table/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+		},
+		"node_modules/table/node_modules/slice-ansi": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+			"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"astral-regex": "^2.0.0",
+				"is-fullwidth-code-point": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
+			}
 		},
 		"node_modules/temp-dir": {
 			"version": "3.0.0",
@@ -13821,6 +14498,34 @@
 				}
 			}
 		},
+		"@csstools/css-parser-algorithms": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.6.3.tgz",
+			"integrity": "sha512-xI/tL2zxzEbESvnSxwFgwvy5HS00oCXxL4MLs6HUiDcYfwowsoQaABKxUElp1ARITrINzBnsECOc1q0eg2GOrA==",
+			"requires": {}
+		},
+		"@csstools/css-tokenizer": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.3.1.tgz",
+			"integrity": "sha512-iMNHTyxLbBlWIfGtabT157LH9DUx9X8+Y3oymFEuMj8HNc+rpE3dPFGFgHjpKfjeFDjLjYIAIhXPGvS2lKxL9g=="
+		},
+		"@csstools/media-query-list-parser": {
+			"version": "2.1.11",
+			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.11.tgz",
+			"integrity": "sha512-uox5MVhvNHqitPP+SynrB1o8oPxPMt2JLgp5ghJOWf54WGQ5OKu47efne49r1SWqs3wRP8xSWjnO9MBKxhB1dA==",
+			"requires": {}
+		},
+		"@csstools/selector-specificity": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.1.1.tgz",
+			"integrity": "sha512-a7cxGcJ2wIlMFLlh8z2ONm+715QkPHiyJcxwQlKOz/03GPw1COpfhcmC9wm4xlZfp//jWHNNMwzjtqHXVWU9KA==",
+			"requires": {}
+		},
+		"@dual-bundle/import-meta-resolve": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
+			"integrity": "sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg=="
+		},
 		"@eslint-community/eslint-utils": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
@@ -15234,6 +15939,11 @@
 				"is-shared-array-buffer": "^1.0.2"
 			}
 		},
+		"astral-regex": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
+		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -15588,6 +16298,11 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
+		"colord": {
+			"version": "2.9.3",
+			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+			"integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw=="
+		},
 		"colorette": {
 			"version": "2.0.20",
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
@@ -15775,6 +16490,25 @@
 					"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
 				}
 			}
+		},
+		"css-functions-list": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.2.tgz",
+			"integrity": "sha512-c+N0v6wbKVxTu5gOBBFkr9BEdBWaqqjQeiJ8QvSRIJOf+UxlJh930m8e6/WNeODIK0mYLFkoONrnj16i2EcvfQ=="
+		},
+		"css-tree": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+			"integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+			"requires": {
+				"mdn-data": "2.0.30",
+				"source-map-js": "^1.0.1"
+			}
+		},
+		"cssesc": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
 		},
 		"cssom": {
 			"version": "0.5.0",
@@ -16414,6 +17148,11 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
 		},
+		"fastest-levenshtein": {
+			"version": "1.0.16",
+			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+			"integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg=="
+		},
 		"fastq": {
 			"version": "1.16.0",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
@@ -16488,9 +17227,9 @@
 			}
 		},
 		"flatted": {
-			"version": "3.2.9",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
-			"integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
 		},
 		"for-each": {
 			"version": "0.3.3",
@@ -16682,6 +17421,39 @@
 				"ini": "4.1.1"
 			}
 		},
+		"global-modules": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+			"integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+			"requires": {
+				"global-prefix": "^3.0.0"
+			}
+		},
+		"global-prefix": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+			"integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+			"requires": {
+				"ini": "^1.3.5",
+				"kind-of": "^6.0.2",
+				"which": "^1.3.1"
+			},
+			"dependencies": {
+				"ini": {
+					"version": "1.3.8",
+					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+					"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+				},
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
+			}
+		},
 		"globals": {
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -16708,6 +17480,11 @@
 				"merge2": "^1.4.1",
 				"slash": "^3.0.0"
 			}
+		},
+		"globjoin": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+			"integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg=="
 		},
 		"gopd": {
 			"version": "1.0.1",
@@ -16828,6 +17605,11 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
 			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
+		},
+		"html-tags": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
+			"integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ=="
 		},
 		"http-proxy-agent": {
 			"version": "5.0.0",
@@ -17095,6 +17877,11 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
 			"integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+		},
+		"is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
 		},
 		"is-potential-custom-element-name": {
 			"version": "1.0.1",
@@ -17812,10 +18599,20 @@
 				"json-buffer": "3.0.1"
 			}
 		},
+		"kind-of": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+		},
 		"kleur": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
 			"integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
+		},
+		"known-css-properties": {
+			"version": "0.31.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.31.0.tgz",
+			"integrity": "sha512-sBPIUGTNF0czz0mwGGUoKKJC8Q7On1GPbCSFPfyEsfHb2DyBG0Y4QtV+EVWpINSaiGKZblDNuF5AezxSgOhesQ=="
 		},
 		"leven": {
 			"version": "3.1.0",
@@ -18085,6 +18882,11 @@
 			"resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
 			"integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="
 		},
+		"lodash.truncate": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+			"integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="
+		},
 		"lodash.uniq": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -18256,6 +19058,16 @@
 				}
 			}
 		},
+		"mathml-tag-names": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
+			"integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg=="
+		},
+		"mdn-data": {
+			"version": "2.0.30",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
+		},
 		"memorystream": {
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
@@ -18335,6 +19147,11 @@
 				"object-assign": "^4.0.1",
 				"thenify-all": "^1.0.0"
 			}
+		},
+		"nanoid": {
+			"version": "3.3.7",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+			"integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
 		},
 		"natural-compare": {
 			"version": "1.4.0",
@@ -20175,9 +20992,9 @@
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
 		},
 		"picocolors": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+			"integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
 		},
 		"picomatch": {
 			"version": "2.3.1",
@@ -20265,6 +21082,60 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
 			"integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q=="
+		},
+		"postcss": {
+			"version": "8.4.38",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+			"integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
+			"requires": {
+				"nanoid": "^3.3.7",
+				"picocolors": "^1.0.0",
+				"source-map-js": "^1.2.0"
+			}
+		},
+		"postcss-media-query-parser": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+			"integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig=="
+		},
+		"postcss-resolve-nested-selector": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
+			"integrity": "sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw=="
+		},
+		"postcss-safe-parser": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.0.tgz",
+			"integrity": "sha512-ovehqRNVCpuFzbXoTb4qLtyzK3xn3t/CUBxOs8LsnQjQrShaB4lKiHoVqY8ANaC0hBMHq5QVWk77rwGklFUDrg==",
+			"requires": {}
+		},
+		"postcss-scss": {
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
+			"integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
+			"requires": {}
+		},
+		"postcss-selector-parser": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.0.tgz",
+			"integrity": "sha512-UMz42UD0UY0EApS0ZL9o1XnLhSTtvvvLe5Dc2H2O56fvRZi+KulDyf5ctDhhtYJBGKStV2FL1fy6253cmLgqVQ==",
+			"requires": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			}
+		},
+		"postcss-styled-syntax": {
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/postcss-styled-syntax/-/postcss-styled-syntax-0.6.4.tgz",
+			"integrity": "sha512-uWiLn+9rKgIghUYmTHvXMR6MnyPULMe9Gv3bV537Fg4FH6CA6cn21WMjKss2Qb98LUhT847tKfnRGG3FhSOgUQ==",
+			"requires": {
+				"typescript": "^5.3.3"
+			}
+		},
+		"postcss-value-parser": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
 		},
 		"prelude-ls": {
 			"version": "1.2.1",
@@ -20936,6 +21807,11 @@
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 		},
+		"source-map-js": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+			"integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg=="
+		},
 		"source-map-support": {
 			"version": "0.5.13",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
@@ -21091,6 +21967,153 @@
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
 		},
+		"stylelint": {
+			"version": "16.6.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.6.1.tgz",
+			"integrity": "sha512-yNgz2PqWLkhH2hw6X9AweV9YvoafbAD5ZsFdKN9BvSDVwGvPh+AUIrn7lYwy1S7IHmtFin75LLfX1m0D2tHu8Q==",
+			"requires": {
+				"@csstools/css-parser-algorithms": "^2.6.3",
+				"@csstools/css-tokenizer": "^2.3.1",
+				"@csstools/media-query-list-parser": "^2.1.11",
+				"@csstools/selector-specificity": "^3.1.1",
+				"@dual-bundle/import-meta-resolve": "^4.1.0",
+				"balanced-match": "^2.0.0",
+				"colord": "^2.9.3",
+				"cosmiconfig": "^9.0.0",
+				"css-functions-list": "^3.2.2",
+				"css-tree": "^2.3.1",
+				"debug": "^4.3.4",
+				"fast-glob": "^3.3.2",
+				"fastest-levenshtein": "^1.0.16",
+				"file-entry-cache": "^9.0.0",
+				"global-modules": "^2.0.0",
+				"globby": "^11.1.0",
+				"globjoin": "^0.1.4",
+				"html-tags": "^3.3.1",
+				"ignore": "^5.3.1",
+				"imurmurhash": "^0.1.4",
+				"is-plain-object": "^5.0.0",
+				"known-css-properties": "^0.31.0",
+				"mathml-tag-names": "^2.1.3",
+				"meow": "^13.2.0",
+				"micromatch": "^4.0.7",
+				"normalize-path": "^3.0.0",
+				"picocolors": "^1.0.1",
+				"postcss": "^8.4.38",
+				"postcss-resolve-nested-selector": "^0.1.1",
+				"postcss-safe-parser": "^7.0.0",
+				"postcss-selector-parser": "^6.1.0",
+				"postcss-value-parser": "^4.2.0",
+				"resolve-from": "^5.0.0",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^7.1.0",
+				"supports-hyperlinks": "^3.0.0",
+				"svg-tags": "^1.0.0",
+				"table": "^6.8.2",
+				"write-file-atomic": "^5.0.1"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+					"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
+				},
+				"balanced-match": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
+					"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA=="
+				},
+				"file-entry-cache": {
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-9.0.0.tgz",
+					"integrity": "sha512-6MgEugi8p2tiUhqO7GnPsmbCCzj0YRCwwaTbpGRyKZesjRSzkqkAE9fPp7V2yMs5hwfgbQLgdvSSkGNg1s5Uvw==",
+					"requires": {
+						"flat-cache": "^5.0.0"
+					}
+				},
+				"flat-cache": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-5.0.0.tgz",
+					"integrity": "sha512-JrqFmyUl2PnPi1OvLyTVHnQvwQ0S+e6lGSwu8OkAZlSaNIZciTY2H/cOOROxsBA1m/LZNHDsqAgDZt6akWcjsQ==",
+					"requires": {
+						"flatted": "^3.3.1",
+						"keyv": "^4.5.4"
+					}
+				},
+				"meow": {
+					"version": "13.2.0",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+					"integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA=="
+				},
+				"signal-exit": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+					"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
+				},
+				"strip-ansi": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+					"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+					"requires": {
+						"ansi-regex": "^6.0.1"
+					}
+				},
+				"write-file-atomic": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+					"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+					"requires": {
+						"imurmurhash": "^0.1.4",
+						"signal-exit": "^4.0.1"
+					}
+				}
+			}
+		},
+		"stylelint-config-recommended": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.0.tgz",
+			"integrity": "sha512-jSkx290CglS8StmrLp2TxAppIajzIBZKYm3IxT89Kg6fGlxbPiTiyH9PS5YUuVAFwaJLl1ikiXX0QWjI0jmgZQ==",
+			"requires": {}
+		},
+		"stylelint-config-recommended-scss": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-14.0.0.tgz",
+			"integrity": "sha512-HDvpoOAQ1RpF+sPbDOT2Q2/YrBDEJDnUymmVmZ7mMCeNiFSdhRdyGEimBkz06wsN+HaFwUh249gDR+I9JR7Onw==",
+			"requires": {
+				"postcss-scss": "^4.0.9",
+				"stylelint-config-recommended": "^14.0.0",
+				"stylelint-scss": "^6.0.0"
+			}
+		},
+		"stylelint-config-standard": {
+			"version": "36.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-36.0.0.tgz",
+			"integrity": "sha512-3Kjyq4d62bYFp/Aq8PMKDwlgUyPU4nacXsjDLWJdNPRUgpuxALu1KnlAHIj36cdtxViVhXexZij65yM0uNIHug==",
+			"requires": {
+				"stylelint-config-recommended": "^14.0.0"
+			}
+		},
+		"stylelint-config-standard-scss": {
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-13.1.0.tgz",
+			"integrity": "sha512-Eo5w7/XvwGHWkeGLtdm2FZLOMYoZl1omP2/jgFCXyl2x5yNz7/8vv4Tj6slHvMSSUNTaGoam/GAZ0ZhukvalfA==",
+			"requires": {
+				"stylelint-config-recommended-scss": "^14.0.0",
+				"stylelint-config-standard": "^36.0.0"
+			}
+		},
+		"stylelint-scss": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.3.1.tgz",
+			"integrity": "sha512-w/czBoWUZxJNk5fBRPODcXSN4qcPv3WHjTSSpFovVY+TE3MZTMR0yRlbmaDYrm8tTWHvpwQAuEBZ0lk2wwkboQ==",
+			"requires": {
+				"known-css-properties": "^0.31.0",
+				"postcss-media-query-parser": "^0.2.3",
+				"postcss-resolve-nested-selector": "^0.1.1",
+				"postcss-selector-parser": "^6.1.0",
+				"postcss-value-parser": "^4.2.0"
+			}
+		},
 		"super-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.0.0.tgz",
@@ -21122,10 +22145,55 @@
 			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
 			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
 		},
+		"svg-tags": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+			"integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA=="
+		},
 		"symbol-tree": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+		},
+		"table": {
+			"version": "6.8.2",
+			"resolved": "https://registry.npmjs.org/table/-/table-6.8.2.tgz",
+			"integrity": "sha512-w2sfv80nrAh2VCbqR5AK27wswXhqcck2AhfnNW76beQXskGZ1V12GwS//yYVa3d3fcvAip2OUnbDAjW2k3v9fA==",
+			"requires": {
+				"ajv": "^8.0.1",
+				"lodash.truncate": "^4.4.2",
+				"slice-ansi": "^4.0.0",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1"
+			},
+			"dependencies": {
+				"ajv": {
+					"version": "8.16.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.16.0.tgz",
+					"integrity": "sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==",
+					"requires": {
+						"fast-deep-equal": "^3.1.3",
+						"json-schema-traverse": "^1.0.0",
+						"require-from-string": "^2.0.2",
+						"uri-js": "^4.4.1"
+					}
+				},
+				"json-schema-traverse": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+				},
+				"slice-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+					"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"astral-regex": "^2.0.0",
+						"is-fullwidth-code-point": "^3.0.0"
+					}
+				}
+			}
 		},
 		"temp-dir": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -73,8 +73,12 @@
 		"jest-environment-jsdom": "29.7.0",
 		"lint-staged": "15.2.5",
 		"npm-run-all2": "6.2.0",
+		"postcss-scss": "4.0.9",
+		"postcss-styled-syntax": "0.6.4",
 		"prettier": "3.3.1",
 		"semantic-release": "23.1.1",
+		"stylelint": "16.6.1",
+		"stylelint-config-standard-scss": "13.1.0",
 		"typescript": "5.4.5"
 	},
 	"devDependencies": {

--- a/src/lint-staged.config.test.ts
+++ b/src/lint-staged.config.test.ts
@@ -15,6 +15,12 @@ describe("it runs the correct commands for", () => {
 		);
 	});
 
+	test("linting files with styles", () => {
+		expect(lintstagedConfig["*.{css,scss,jsx,tsx}" as keyof Config]).toEqual(
+			"npm run lint.styles -- --fix",
+		);
+	});
+
 	const [lintJavaScriptTypeScriptCommand, typecheckCommand] =
 		// @ts-expect-error TODO: Figure out how to correctly type the function on this configuration object.
 		lintstagedConfig["*.{js,jsx,ts,tsx}"](relativePaths);

--- a/src/lint-staged.config.ts
+++ b/src/lint-staged.config.ts
@@ -8,6 +8,7 @@ const lintstagedConfig: Config = {
 	 */
 	// Fix code formatting for all file types that Prettier supports.
 	"*": "npm run format -- --ignore-unknown --write",
+	"*.{css,scss,jsx,tsx}": "npm run lint.styles -- --fix",
 	"*.{js,jsx,ts,tsx}": (relativePaths) => [
 		// Fix code issues for all file types that ESLint supports.
 		`npm run lint.js-ts -- --fix ${relativePaths.join(" ")}`,

--- a/src/stylelint.config.test.ts
+++ b/src/stylelint.config.test.ts
@@ -1,5 +1,54 @@
-import stylelintConfig from "./stylelint.config.js";
+import {dependsOnMock} from "./utils/dependsOn.mock.js";
+import {makeStylelintConfig} from "./stylelint.config.js";
 
-test("it exports a configuration object and the most important config options are correct", () => {
-	expect(typeof stylelintConfig).toEqual("object");
+describe("it exports a configuration object and the most important config options are correct", () => {
+	test("for the parts of the config that *are not* affected by conditional logic", async () => {
+		const stylelintConfig = await makeStylelintConfig();
+
+		expect(typeof stylelintConfig).toEqual("object");
+
+		expect(stylelintConfig.extends).toStrictEqual([
+			"stylelint-config-standard",
+		]);
+		expect(stylelintConfig.reportDescriptionlessDisables).toBe(true);
+		expect(stylelintConfig.reportInvalidScopeDisables).toBe(true);
+		expect(stylelintConfig.reportNeedlessDisables).toBe(true);
+		expect(stylelintConfig.rules?.["no-unknown-custom-properties"]).toBe(true);
+		expect(stylelintConfig.rules?.["declaration-no-important"]).toBe(true);
+		expect(stylelintConfig.rules?.["unit-disallowed-list"]).toStrictEqual([
+			"em",
+		]);
+		expect(stylelintConfig.rules?.["max-nesting-depth"]).toEqual(3);
+		expect(stylelintConfig.rules?.["font-weight-notation"]).toEqual("numeric");
+	});
+
+	test("when testing this web-dev-deps repo (which *does not* have frontend style-related dependencies)", async () => {
+		const hasFrontendStyleDependencies = false;
+		dependsOnMock.mockResolvedValue(hasFrontendStyleDependencies);
+
+		const stylelintConfig = await makeStylelintConfig();
+
+		expect(dependsOnMock).toHaveBeenCalledWith(["sass"]);
+		expect(dependsOnMock).toHaveBeenCalledWith(["styled-components"]);
+		expect(stylelintConfig.overrides).toStrictEqual([]);
+	});
+
+	test("when testing a repo that has installed the sass package", async () => {
+		const hasSassDependency = true;
+		dependsOnMock.mockResolvedValue(hasSassDependency);
+
+		const stylelintConfig = await makeStylelintConfig();
+
+		expect(stylelintConfig.extends).toEqual(
+			expect.arrayContaining(["stylelint-config-standard-scss"]),
+		);
+		expect(stylelintConfig.overrides).toEqual(
+			expect.arrayContaining([
+				{
+					customSyntax: "postcss-scss",
+					files: ["**/*.scss"],
+				},
+			]),
+		);
+	});
 });

--- a/src/stylelint.config.test.ts
+++ b/src/stylelint.config.test.ts
@@ -1,0 +1,5 @@
+import stylelintConfig from "./stylelint.config.js";
+
+test("it exports a configuration object and the most important config options are correct", () => {
+	expect(typeof stylelintConfig).toEqual("object");
+});

--- a/src/stylelint.config.ts
+++ b/src/stylelint.config.ts
@@ -1,40 +1,63 @@
 import type {Config} from "stylelint";
+import {dependsOn} from "./utils/dependsOn.js";
 
 /** https://stylelint.io/user-guide/configure */
-const stylelintConfig: Config = {
-	extends: ["stylelint-config-standard", "stylelint-config-standard-scss"],
-	rules: {
-		// https://stylelint.io/user-guide/rules#avoid-errors
-		// > This rule considers the identifiers of `@keyframes` rules defined within the same source to be known.
-		"no-unknown-animations": true,
-		// > This rule considers custom media queries defined **within the same source** to be known.
-		"no-unknown-custom-media": true,
-		// > This rule considers custom properties defined within the same source to be known.
-		"no-unknown-custom-properties": true,
-		// https://stylelint.io/user-guide/rules#enforce-conventions
-		// > Disallow `!important` within declarations.
-		"declaration-no-important": true,
-		// > Limit the depth of nesting.
-		// > **Note**: root-level at-rules will **not be included** in the nesting depth calculation, because
-		// > most users would take for granted that root-level at-rules are "free" (since they're necessary).
-		"max-nesting-depth": 3,
-		// > Require numeric or named (where possible) `font-weight` values.
-		"font-weight-notation": "numeric",
-	},
+export const makeStylelintConfig = async (): Promise<Config> => {
+	const hasSassDependency = await dependsOn(["sass"]);
+	const hasStyledComponentsDependency = await dependsOn(["styled-components"]);
+
+	const overrides: Config["overrides"] = [];
 	// Use two plugins from https://stylelint.io/awesome-stylelint#custom-syntaxes
 	// to enable Stylelint to check Sass and styled-components code.
-	overrides: [
+	if (hasSassDependency) {
 		// https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint#only-css-and-postcss-are-validated-by-default
-		{
+		overrides.push({
 			customSyntax: "postcss-scss",
 			files: ["**/*.scss"],
-		},
+		});
+	}
+	if (hasStyledComponentsDependency) {
 		// https://github.com/hudochenkov/postcss-styled-syntax#stylelint
-		{
+		overrides.push({
 			customSyntax: "postcss-styled-syntax",
 			files: ["**/*.{jsx,tsx}"],
-		},
-	],
-} as const;
+		});
+	}
 
-export default stylelintConfig;
+	return {
+		extends: [
+			"stylelint-config-standard",
+			// Conditionally extend the standard SCSS configuration if the consuming repository has a dependency on the `sass` package.
+			...(hasSassDependency ? ["stylelint-config-standard-scss"] : []),
+		],
+		// Excerpt from https://stylelint.io/user-guide/configure#report:
+		// > These `report*` properties provide extra validation for `stylelint-disable` comments.
+		// > This can help enforce useful and well-documented disables.
+		reportDescriptionlessDisables: true,
+		reportInvalidScopeDisables: true,
+		reportNeedlessDisables: true,
+		rules: {
+			// https://stylelint.io/user-guide/rules#avoid-errors
+			// > This rule considers the identifiers of `@keyframes` rules defined within the same source to be known.
+			"no-unknown-animations": true,
+			// > This rule considers custom media queries defined **within the same source** to be known.
+			"no-unknown-custom-media": true,
+			// > This rule considers custom properties defined within the same source to be known.
+			"no-unknown-custom-properties": true,
+			// https://stylelint.io/user-guide/rules#enforce-conventions
+			// > Disallow `!important` within declarations.
+			"declaration-no-important": true,
+			// > Specify a list of disallowed units.
+			"unit-disallowed-list": ["em"],
+			// > Limit the depth of nesting.
+			// > **Note**: root-level at-rules will **not be included** in the nesting depth calculation, because
+			// > most users would take for granted that root-level at-rules are "free" (since they're necessary).
+			"max-nesting-depth": 3,
+			// > Require numeric or named (where possible) `font-weight` values.
+			"font-weight-notation": "numeric",
+		},
+		overrides,
+	};
+};
+
+export default makeStylelintConfig();

--- a/src/stylelint.config.ts
+++ b/src/stylelint.config.ts
@@ -1,0 +1,40 @@
+import type {Config} from "stylelint";
+
+/** https://stylelint.io/user-guide/configure */
+const stylelintConfig: Config = {
+	extends: ["stylelint-config-standard", "stylelint-config-standard-scss"],
+	rules: {
+		// https://stylelint.io/user-guide/rules#avoid-errors
+		// > This rule considers the identifiers of `@keyframes` rules defined within the same source to be known.
+		"no-unknown-animations": true,
+		// > This rule considers custom media queries defined **within the same source** to be known.
+		"no-unknown-custom-media": true,
+		// > This rule considers custom properties defined within the same source to be known.
+		"no-unknown-custom-properties": true,
+		// https://stylelint.io/user-guide/rules#enforce-conventions
+		// > Disallow `!important` within declarations.
+		"declaration-no-important": true,
+		// > Limit the depth of nesting.
+		// > **Note**: root-level at-rules will **not be included** in the nesting depth calculation, because
+		// > most users would take for granted that root-level at-rules are "free" (since they're necessary).
+		"max-nesting-depth": 3,
+		// > Require numeric or named (where possible) `font-weight` values.
+		"font-weight-notation": "numeric",
+	},
+	// Use two plugins from https://stylelint.io/awesome-stylelint#custom-syntaxes
+	// to enable Stylelint to check Sass and styled-components code.
+	overrides: [
+		// https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint#only-css-and-postcss-are-validated-by-default
+		{
+			customSyntax: "postcss-scss",
+			files: ["**/*.scss"],
+		},
+		// https://github.com/hudochenkov/postcss-styled-syntax#stylelint
+		{
+			customSyntax: "postcss-styled-syntax",
+			files: ["**/*.{jsx,tsx}"],
+		},
+	],
+} as const;
+
+export default stylelintConfig;


### PR DESCRIPTION
Summary of changes:

- Install `stylelint` as a dependency.
  - Also install `stylelint-config-standard-scss`, `postcss-scss` and `postcss-styled-syntax` as dependencies so that Stylelint can report style errors for Sass and styled-components code.
- Compile `stylelint.config.ts` to the `lib/` directory.